### PR TITLE
Run "create_kind_clusters" sequentially

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -200,7 +200,7 @@ mkdir -p ${work_dir}
 i=1
 for cluster in "${clusters[@]}";
 do
-    (create_kind_cluster "$i" "$cluster") &
+    create_kind_cluster "$i" "$cluster"
     i=$(($i+1))
 done
 wait


### PR DESCRIPTION
Avoid running the creation of kind clusters simultaneously as it leads to network ambiguity

Closes #15 

Signed-off-by: Steve Mattar <smattar@redhat.com>