### PR TITLE
Add apiVersion string to the ManagedClusterSet resource in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The steps below can be used to test with OpenShift Container Platform (OCP) clus
 1. Create a `ManagedClusterSet`.
 
    ```
+   apiVersion: cluster.open-cluster-management.io/v1alpha1
    kind: ManagedClusterSet
    metadata:
      name: pro


### PR DESCRIPTION
Add apiVersion string in the README section named "Setup Submariner on the Hub cluster", step 1. This avoid validation errors when submitting the resource in the hub cluster.