### PR TITLE
add crd/finalizers role

### DIFF
--- a/deploy/config/rbac/cluster_role.yaml
+++ b/deploy/config/rbac/cluster_role.yaml
@@ -22,7 +22,7 @@ rules:
   resources: ["clusterroles", "roles"]
   verbs: ["create", "get", "list", "update", "watch", "patch", "delete", "escalate", "bind"]
 - apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
+  resources: ["customresourcedefinitions","customresourcedefinitions/finalizers"]
   verbs: ["create", "get", "list", "update", "watch", "patch", "delete"]
 - apiGroups: ["cluster.open-cluster-management.io"]
   resources: ["managedclusters","managedclustersets"]

--- a/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
@@ -96,6 +96,7 @@ spec:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
+          - customresourcedefinitions/finalizers
           verbs:
           - create
           - get


### PR DESCRIPTION
OCP needs crds/finalizers role since the error 
```
 customresourcedefinitions.apiextensions.k8s.io "gateways.submariner.io" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```