### PR TITLE
Enable PR dependency check jobs

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,0 +1,38 @@
+---
+name: PR Dependencies
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+  schedule:
+    - cron: '0 0/6 * * *'  # every 6 hours
+
+jobs:
+  check:
+    name: Check Dependencies
+    if: github.repository_owner == 'open-cluster-management'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: z0al/dependent-issues@65a8dadac8eb87a2ea821f277fe5529d86609558
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # The label to use to mark dependent issues
+          label: dependent
+
+          # Enable checking for dependencies in issues.
+          check_issues: on
+
+          # A comma-separated list of keywords to mark dependency.
+          keywords: depends on, Depends on


### PR DESCRIPTION
This job marks a PR `dependent` whenever a dependent PR
is mentioned via `Depends on/ depends on` keyword.

The job fails until the dependent PR is not merged. This
helps in properly managing merging of dependent PRs.

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>