### PR TITLE
Add golangci-lint make target, linter config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,90 @@
+---
+linters-settings:
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - opinionated
+      # - performance
+      - style
+    disabled-checks:
+      - ifElseChain
+      - unnamedResult
+  gocyclo:
+    min-complexity: 20
+  govet:
+    enable:
+      - fieldalignment
+  lll:
+    line-length: 140
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    # - deadcode
+    - depguard
+    - dogsled
+    # - dupl
+    # - errcheck
+    - exportloopref
+    # - funlen
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - goconst
+    # - gocritic
+    # - gocyclo
+    - gofmt
+    # - goimports
+    # - gosec
+    # - gosimple
+    - govet
+    - ineffassign
+    # - lll
+    # - misspell
+    - nakedret
+    # - prealloc
+    # - staticcheck
+    - structcheck
+    # - stylecheck  # instead of golint
+    # - testpackage
+    - typecheck
+    # - unconvert
+    # - unparam
+    # - unused
+    # - varcheck
+    # - whitespace
+    # - wsl
+issues:
+  exclude-rules:
+    # Separating explicit var declarations by blank lines seems excessive.
+    - linters:
+        - wsl
+      text: "declarations should never be cuddled"
+
+    # This rule incorrectly flags code where two logically-related lines are
+    # followed by an if conditional to check their err return.
+    - linters:
+        - wsl
+      text: "only one cuddle assignment allowed before if statement"
+
+    # This rule incorrectly flags code where two logically-related lines are
+    # used to create vars that are consumed in a loop.
+    - linters:
+        - wsl
+      text: "only one cuddle assignment allowed before range statement"
+
+    # Allow dot imports for `fake` directory and e2e tests
+    - linters:
+        - stylecheck
+      text: "ST1001: "
+      path: /fake
+
+    - linters:
+        - stylecheck
+      text: "ST1001: "
+      path: test
+
+    # Ignore pointer bytes in struct alignment tests (this is a very
+    # minor optimisation)
+    - linters:
+        - govet
+      text: "pointer bytes could be"

--- a/Makefile
+++ b/Makefile
@@ -115,3 +115,8 @@ CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
+
+# [golangci-lint] validates Go code in the project
+golangci-lint:
+	golangci-lint linters
+	golangci-lint run --timeout 10m


### PR DESCRIPTION
Add a make target for running Go linting via golangci-lint.

Add configuration for golangci-lint, copied from the main Submariner
repo. Disable all currently-failing tests.

This will be consumed by Prow to run CI. The tool install will be
handled by Prow.

To use locally, golangci-lint and go >1.15 are required.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>