### PR TITLE
Ignore the IKE port

### DIFF
--- a/pkg/cloud/aws/aws_test.go
+++ b/pkg/cloud/aws/aws_test.go
@@ -135,7 +135,7 @@ func TestPrepareSubmarinerClusterEnv(t *testing.T) {
 				}).Return(&ec2.CreateSecurityGroupOutput{GroupId: aws.String("sg-3")}, nil)
 				mock.EXPECT().AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
 					GroupId:       aws.String("sg-3"),
-					IpPermissions: getIPsecPortsPermission(int64(500), int64(4500), int64(4900)),
+					IpPermissions: getIPsecPortsPermission(int64(4500), int64(4900)),
 				}).Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil)
 				mock.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
 					Filters: []*ec2.Filter{
@@ -273,7 +273,7 @@ func TestPrepareSubmarinerClusterEnv(t *testing.T) {
 				}).Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, awserr.New("InvalidPermission.Duplicate", "test", nil))
 				gwSG := &ec2.SecurityGroup{
 					GroupId:       aws.String("sg-3"),
-					IpPermissions: getIPsecPortsPermission(int64(500), int64(4500), int64(4900)),
+					IpPermissions: getIPsecPortsPermission(int64(4500), int64(4900)),
 				}
 				mock.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
 					Filters: []*ec2.Filter{
@@ -352,7 +352,6 @@ func TestPrepareSubmarinerClusterEnv(t *testing.T) {
 				awsClinet:         awsClient,
 				region:            "us-east-1",
 				infraId:           "testcluster-a1b1",
-				ikePort:           int64(500),
 				nattPort:          int64(4500),
 				nattDiscoveryPort: int64(4900),
 				clusterName:       "testcluster",
@@ -438,7 +437,7 @@ func TestCleanUpSubmarinerClusterEnv(t *testing.T) {
 					},
 					Resources: []*string{aws.String("sub-1")},
 				}).Return(&ec2.DeleteTagsOutput{}, nil)
-				sg := &ec2.SecurityGroup{GroupId: aws.String("sg-3"), IpPermissions: getIPsecPortsPermission(int64(500),
+				sg := &ec2.SecurityGroup{GroupId: aws.String("sg-3"), IpPermissions: getIPsecPortsPermission(
 					int64(4500), int64(4900))}
 				mock.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
 					Filters: []*ec2.Filter{
@@ -524,7 +523,6 @@ func TestCleanUpSubmarinerClusterEnv(t *testing.T) {
 				awsClinet:         awsClient,
 				region:            "us-east-1",
 				infraId:           "testcluster-a1b1",
-				ikePort:           int64(500),
 				nattPort:          int64(4500),
 				nattDiscoveryPort: int64(4900),
 				clusterName:       "testcluster",

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -46,7 +46,7 @@ func GetCloudProvider(
 			eventsRecorder,
 			region, infraId, clusterName, config.Spec.CredentialsSecret.Name,
 			config.Spec.GatewayConfig.AWS.InstanceType,
-			config.Spec.IPSecIKEPort, config.Spec.IPSecNATTPort, config.Spec.NATTDiscoveryPort,
+			config.Spec.IPSecNATTPort, config.Spec.NATTDiscoveryPort,
 			config.Spec.Gateways,
 		)
 	case "GCP":
@@ -54,7 +54,7 @@ func GetCloudProvider(
 			kubeClient,
 			eventsRecorder,
 			infraId, clusterName, config.Spec.CredentialsSecret.Name,
-			config.Spec.IPSecIKEPort, config.Spec.IPSecNATTPort, config.Spec.NATTDiscoveryPort,
+			config.Spec.IPSecNATTPort, config.Spec.NATTDiscoveryPort,
 		)
 	}
 	return nil, fmt.Errorf("unsupported cloud platform %q of cluster %q", platform, clusterName)

--- a/pkg/cloud/gcp/gcp.go
+++ b/pkg/cloud/gcp/gcp.go
@@ -25,7 +25,6 @@ const (
 type gcpProvider struct {
 	infraId           string
 	projectId         string
-	ikePort           string
 	nattPort          string
 	nattDiscoveryPort string
 	routePort         string
@@ -38,13 +37,9 @@ func NewGCPProvider(
 	kubeClient kubernetes.Interface,
 	eventRecorder events.Recorder,
 	infraId, clusterName, credentialsSecretName string,
-	ikePort, nattPort, nattDiscoveryPort int) (*gcpProvider, error) {
+	nattPort, nattDiscoveryPort int) (*gcpProvider, error) {
 	if infraId == "" {
 		return nil, fmt.Errorf("cluster infraId is empty")
-	}
-
-	if ikePort == 0 {
-		ikePort = helpers.SubmarinerIKEPort
 	}
 
 	if nattPort == 0 {
@@ -63,7 +58,6 @@ func NewGCPProvider(
 	return &gcpProvider{
 		infraId:           infraId,
 		projectId:         gcpClient.GetProjectID(),
-		ikePort:           strconv.Itoa(ikePort),
 		nattPort:          strconv.Itoa(nattPort),
 		nattDiscoveryPort: strconv.Itoa(nattDiscoveryPort),
 		routePort:         strconv.Itoa(helpers.SubmarinerRoutePort),
@@ -84,7 +78,7 @@ func NewGCPProvider(
 func (g *gcpProvider) PrepareSubmarinerClusterEnv() error {
 	// open IPsec IKE port (by default 500/UDP), NAT traversal port (by default 4500/UDP),
 	// NAT Traversal discovery port (by default 4900/udp) and route port (4800/UDP)
-	ports := []string{g.ikePort, g.nattPort, g.nattDiscoveryPort, g.routePort}
+	ports := []string{g.nattPort, g.nattDiscoveryPort, g.routePort}
 	ingress, egress := newFirewallRules(submarinerRuleName, g.projectId, g.infraId, "udp", ports)
 	if err := g.openPorts(ingress, egress); err != nil {
 		return fmt.Errorf("failed to open submariner ports: %v", err)

--- a/pkg/cloud/gcp/gcp_test.go
+++ b/pkg/cloud/gcp/gcp_test.go
@@ -15,14 +15,12 @@ import (
 func TestPrepareSubmarinerClusterEnv(t *testing.T) {
 	cases := []struct {
 		name              string
-		ikePort           string
 		nattPort          string
 		nattDiscoveryPort string
 		expectInvoking    func(*mock.MockInterface)
 	}{
 		{
 			name:              "build submariner env",
-			ikePort:           "500",
 			nattPort:          "4500",
 			nattDiscoveryPort: "4900",
 			expectInvoking: func(gcpClient *mock.MockInterface) {
@@ -33,7 +31,7 @@ func TestPrepareSubmarinerClusterEnv(t *testing.T) {
 				gcpClient.EXPECT().GetFirewallRule("test-x595d-submariner-metrics-egress").Return(nil, &googleapi.Error{Code: 404})
 
 				// instert rules
-				ingress, egress := newFirewallRules(submarinerRuleName, "test", "test-x595d", "udp", []string{"500", "4500", "4900", "4800"})
+				ingress, egress := newFirewallRules(submarinerRuleName, "test", "test-x595d", "udp", []string{"4500", "4900", "4800"})
 				gcpClient.EXPECT().InsertFirewallRule(ingress).Return(nil)
 				gcpClient.EXPECT().InsertFirewallRule(egress).Return(nil)
 				mIngress, mEgress := newFirewallRules(submarinerMetricsRuleName, "test", "test-x595d", "tcp", []string{"8080"})
@@ -43,12 +41,11 @@ func TestPrepareSubmarinerClusterEnv(t *testing.T) {
 		},
 		{
 			name:              "rebuild submariner env - no update",
-			ikePort:           "500",
 			nattPort:          "4500",
 			nattDiscoveryPort: "4900",
 			expectInvoking: func(gcpClient *mock.MockInterface) {
 				// get rules
-				ingress, egress := newFirewallRules(submarinerRuleName, "test", "test-x595d", "udp", []string{"500", "4500", "4900", "4800"})
+				ingress, egress := newFirewallRules(submarinerRuleName, "test", "test-x595d", "udp", []string{"4500", "4900", "4800"})
 				gcpClient.EXPECT().GetFirewallRule("test-x595d-submariner-ingress").Return(ingress, nil)
 				gcpClient.EXPECT().GetFirewallRule("test-x595d-submariner-egress").Return(egress, nil)
 				mIngress, mEgress := newFirewallRules(submarinerMetricsRuleName, "test", "test-x595d", "tcp", []string{"8080"})
@@ -58,12 +55,11 @@ func TestPrepareSubmarinerClusterEnv(t *testing.T) {
 		},
 		{
 			name:              "rebuild submariner env - update",
-			ikePort:           "501",
 			nattPort:          "4501",
 			nattDiscoveryPort: "4901",
 			expectInvoking: func(gcpClient *mock.MockInterface) {
 				// get rules
-				ingress, egress := newFirewallRules(submarinerRuleName, "test", "test-x595d", "udp", []string{"500", "4500", "4900", "4800"})
+				ingress, egress := newFirewallRules(submarinerRuleName, "test", "test-x595d", "udp", []string{"4500", "4900", "4800"})
 				gcpClient.EXPECT().GetFirewallRule("test-x595d-submariner-ingress").Return(ingress, nil)
 				gcpClient.EXPECT().GetFirewallRule("test-x595d-submariner-egress").Return(egress, nil)
 				mIngress, mEgress := newFirewallRules(submarinerMetricsRuleName, "test", "test-x595d", "tcp", []string{"8080"})
@@ -71,7 +67,7 @@ func TestPrepareSubmarinerClusterEnv(t *testing.T) {
 				gcpClient.EXPECT().GetFirewallRule("test-x595d-submariner-metrics-egress").Return(mEgress, nil)
 
 				// udpate rules
-				newIngress, newEgress := newFirewallRules(submarinerRuleName, "test", "test-x595d", "udp", []string{"501", "4501", "4901", "4800"})
+				newIngress, newEgress := newFirewallRules(submarinerRuleName, "test", "test-x595d", "udp", []string{"4501", "4901", "4800"})
 				gcpClient.EXPECT().UpdateFirewallRule("test-x595d-submariner-ingress", newIngress).Return(nil)
 				gcpClient.EXPECT().UpdateFirewallRule("test-x595d-submariner-egress", newEgress).Return(nil)
 			},
@@ -89,7 +85,6 @@ func TestPrepareSubmarinerClusterEnv(t *testing.T) {
 			gp := &gcpProvider{
 				infraId:           "test-x595d",
 				projectId:         "test",
-				ikePort:           c.ikePort,
 				nattPort:          c.nattPort,
 				nattDiscoveryPort: c.nattDiscoveryPort,
 				routePort:         "4800",

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -62,7 +62,6 @@ const (
 )
 
 const (
-	SubmarinerIKEPort           = 500
 	SubmarinerNatTPort          = 4500
 	SubmarinerNatTDiscoveryPort = 4900
 	SubmarinerRoutePort         = 4800

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -64,7 +64,6 @@ func NewSubmarinerBrokerInfo(
 	managedClusterAddOn *addonv1alpha1.ManagedClusterAddOn) (*SubmarinerBrokerInfo, error) {
 	brokerInfo := &SubmarinerBrokerInfo{
 		CableDriver:            defaultCableDriver,
-		IPSecIKEPort:           helpers.SubmarinerIKEPort,
 		IPSecNATTPort:          helpers.SubmarinerNatTPort,
 		BrokerNamespace:        brokeNamespace,
 		ClusterName:            managedCluster.Name,


### PR DESCRIPTION
This is no longer used. The field is left in the SubmarinerConfig spec
to avoid breakage.

Signed-off-by: Stephen Kitt <skitt@redhat.com>