### PR TITLE
Add a ManifestWork-based MachineSet deployer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/prometheus/procfs v0.7.2 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
+	github.com/submariner-io/admiral v0.11.0-m2
 	github.com/submariner-io/cloud-prepare v0.11.0-m2.0.20210920144917-0b33718646a7
 	github.com/submariner-io/submariner-operator/apis v0.0.0-20210817145008-861856b068a1
 	github.com/submariner-io/submariner/pkg/apis v0.0.0-20210817085048-59f656555db0

--- a/pkg/cloud/manifestwork/machineset.go
+++ b/pkg/cloud/manifestwork/machineset.go
@@ -1,0 +1,108 @@
+package manifestwork
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/open-cluster-management/submariner-addon/pkg/helpers"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/cloud-prepare/pkg/ocp"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	workclient "open-cluster-management.io/api/client/work/clientset/versioned"
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+type manifestWorkMachineSetDeployer struct {
+	client        workclient.Interface
+	workName      string
+	clusterName   string
+	eventRecorder events.Recorder
+}
+
+// NewMachineSetDeployer creates a new MachineSet deployer which uses ManifestWork
+func NewMachineSetDeployer(client workclient.Interface, workName, clusterName string, eventRecorder events.Recorder) ocp.MachineSetDeployer {
+	return &manifestWorkMachineSetDeployer{
+		client:        client,
+		workName:      workName,
+		clusterName:   clusterName,
+		eventRecorder: eventRecorder,
+	}
+}
+
+func (msd *manifestWorkMachineSetDeployer) Deploy(machineSet *unstructured.Unstructured) error {
+	manifests := []workv1.Manifest{}
+
+	// Ensure that we're allowed to manipulate machinesets
+	aggregateClusterRole := rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "open-cluster-management:submariner-addon-machinesets-aggregate-clusterrole",
+			Labels: map[string]string{
+				"rbac.authorization.k8s.io/aggregate-to-admin": "true",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"machine.openshift.io"},
+				Resources: []string{"machinesets"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+		},
+	}
+	unstructuredClusterRole, err := resource.ToUnstructured(&aggregateClusterRole)
+	if err != nil {
+		return err
+	}
+	aggregateClusterRoleJson, err := toJSON(unstructuredClusterRole)
+	if err != nil {
+		return err
+	}
+	manifests = append(manifests, workv1.Manifest{RawExtension: runtime.RawExtension{Raw: aggregateClusterRoleJson}})
+
+	machineSetJson, err := machineSet.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	manifests = append(manifests, workv1.Manifest{RawExtension: runtime.RawExtension{Raw: machineSetJson}})
+
+	return helpers.ApplyManifestWork(context.TODO(), msd.client, &workv1.ManifestWork{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      msd.workName,
+			Namespace: msd.clusterName,
+		},
+		Spec: workv1.ManifestWorkSpec{
+			Workload: workv1.ManifestsTemplate{Manifests: manifests},
+		},
+	}, msd.eventRecorder)
+}
+
+func (msd *manifestWorkMachineSetDeployer) GetWorkerNodeImage(machineSet *unstructured.Unstructured, infraID string) (string, error) {
+	// This isn't used for AWS
+	return "", nil
+}
+
+func (msd *manifestWorkMachineSetDeployer) Delete(machineSet *unstructured.Unstructured) error {
+	err := msd.client.WorkV1().ManifestWorks(msd.clusterName).Delete(context.TODO(), machineSet.GetName(), metav1.DeleteOptions{})
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func toJSON(obj runtime.Object) ([]byte, error) {
+	jsonSerializer := json.NewSerializer(json.DefaultMetaFactory, nil, nil, false)
+
+	var b bytes.Buffer
+	writer := json.Framer.NewFrameWriter(&b)
+	if err := jsonSerializer.Encode(obj, writer); err != nil {
+		return []byte{}, err
+	} else {
+		return b.Bytes(), nil
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -318,6 +318,7 @@ github.com/spf13/cobra
 ## explicit
 github.com/spf13/pflag
 # github.com/submariner-io/admiral v0.11.0-m2
+## explicit
 github.com/submariner-io/admiral/pkg/log
 github.com/submariner-io/admiral/pkg/resource
 github.com/submariner-io/admiral/pkg/util


### PR DESCRIPTION
This is required to manage deployments through the hub.

Signed-off-by: Stephen Kitt <skitt@redhat.com>