### PR TITLE
Update openshift/build-machinery-go to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0
 	github.com/openshift/api v0.0.0-20210521075222-e273a339932a
-	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
+	github.com/openshift/build-machinery-go v0.0.0-20210922160744-a9caf93aef90
 	github.com/openshift/library-go v0.0.0-20210609150209-1c980926414c
 	github.com/operator-framework/api v0.5.2
 	github.com/prometheus/common v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -471,7 +471,6 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/openshift/api v0.0.0-20210521075222-e273a339932a h1:aBPwLqCg66SbQd+HrjB1GhgTfPtqSY4aeB022tEYmE0=
 github.com/openshift/api v0.0.0-20210521075222-e273a339932a/go.mod h1:izBmoXbUu3z5kUa4FjZhvekTsyzIWiOoaIgJiZBBMQs=
 github.com/openshift/build-machinery-go v0.0.0-20210115170933-e575b44a7a94/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
-github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e h1:F7rBobgSjtYL3/zsgDUjlTVx3Z06hdgpoldpDcn7jzc=
 github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210922160744-a9caf93aef90 h1:UUq18A+3oxNPCLvgSbhwKfMhVX3SQWOeJKcXkMkumek=
 github.com/openshift/build-machinery-go v0.0.0-20210922160744-a9caf93aef90/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=

--- a/go.sum
+++ b/go.sum
@@ -473,6 +473,8 @@ github.com/openshift/api v0.0.0-20210521075222-e273a339932a/go.mod h1:izBmoXbUu3
 github.com/openshift/build-machinery-go v0.0.0-20210115170933-e575b44a7a94/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e h1:F7rBobgSjtYL3/zsgDUjlTVx3Z06hdgpoldpDcn7jzc=
 github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20210922160744-a9caf93aef90 h1:UUq18A+3oxNPCLvgSbhwKfMhVX3SQWOeJKcXkMkumek=
+github.com/openshift/build-machinery-go v0.0.0-20210922160744-a9caf93aef90/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/openshift/library-go v0.0.0-20210609150209-1c980926414c h1:1U/zY54WyRyEsVoAHf6yLDgSHf5famdKnIBulyGOLGU=
 github.com/openshift/library-go v0.0.0-20210609150209-1c980926414c/go.mod h1:C5DDOSPucn3EVA0T05fODKtAweTObMBrTYm/G3uUBI8=

--- a/vendor/github.com/openshift/build-machinery-go/OWNERS
+++ b/vendor/github.com/openshift/build-machinery-go/OWNERS
@@ -2,6 +2,7 @@ reviewers:
   - sttts
   - mfojtik
   - soltysh
+  - 2uasimojo
 approvers:
   - sttts
   - mfojtik

--- a/vendor/github.com/openshift/build-machinery-go/make/default.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/default.example.mk.help.log
@@ -3,6 +3,7 @@ all
 build
 clean
 clean-binaries
+ensure-imagebuilder
 help
 image-ocp-cli
 images

--- a/vendor/github.com/openshift/build-machinery-go/make/default.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/default.mk
@@ -1,4 +1,10 @@
-self_dir := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	targets/openshift/deps.mk \
+	targets/openshift/images.mk \
+	targets/openshift/bindata.mk \
+	targets/openshift/codegen.mk \
+	golang.mk \
+)
 
 # We extend the default verify/update for Golang
 
@@ -9,15 +15,3 @@ verify: verify-bindata
 update: update-codegen
 update: update-bindata
 .PHONY: update
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	targets/openshift/deps.mk \
-	targets/openshift/images.mk \
-	targets/openshift/bindata.mk \
-	targets/openshift/codegen.mk \
-	golang.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/golang.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/golang.mk
@@ -1,8 +1,10 @@
 all: build
 .PHONY: all
 
-self_dir := $(dir $(lastword $(MAKEFILE_LIST)))
-
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	targets/help.mk \
+	targets/golang/*.mk \
+)
 
 verify: verify-gofmt
 verify: verify-govet
@@ -18,12 +20,3 @@ test: test-unit
 
 clean: clean-binaries
 .PHONY: clean
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	targets/help.mk \
-	targets/golang/*.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
@@ -16,7 +16,7 @@ GOFMT ?=gofmt
 GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
-go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+.[0-9]+).*/\1/')
+go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+(.[0-9]+)?).*/\1/')
 GO_REQUIRED_MIN_VERSION ?=1.15.2
 ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
 $(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(go_version))

--- a/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
@@ -5,6 +5,7 @@ clean
 clean-binaries
 clean-yaml-patch
 clean-yq
+ensure-imagebuilder
 ensure-yaml-patch
 ensure-yq
 help

--- a/vendor/github.com/openshift/build-machinery-go/make/operator.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/operator.mk
@@ -1,11 +1,4 @@
-self_dir := $(dir $(lastword $(MAKEFILE_LIST)))
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 	default.mk \
 	targets/openshift/operator/*.mk \
 )
-

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/build.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/build.mk
@@ -1,4 +1,6 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+)
 
 define build-package
 	$(if $(GO_BUILD_BINDIR),mkdir -p '$(GO_BUILD_BINDIR)',)
@@ -20,10 +22,3 @@ clean-binaries:
 
 clean: clean-binaries
 .PHONY: clean
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk
@@ -1,4 +1,6 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+)
 
 test-unit:
 ifndef JUNITFILE
@@ -10,10 +12,3 @@ endif
 	set -o pipefail; $(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) -json $(GO_TEST_PACKAGES) | gotest2junit > $(JUNITFILE)
 endif
 .PHONY: test-unit
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/verify-update.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/verify-update.mk
@@ -1,4 +1,6 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+)
 
 go_files_count :=$(words $(GO_FILES))
 
@@ -26,11 +28,4 @@ verify-govet:
 
 verify-golint:
 	$(GOLINT) $(GO_PACKAGES)
-.PHONY: verify-govet
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)
+.PHONY: verify-golint

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/version.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/version.mk
@@ -1,8 +1,11 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)
 
 .empty-golang-versions-files:
 	@rm -f "$(PERMANENT_TMP)/golang-versions" "$(PERMANENT_TMP)/named-golang-versions"
-.PHONE: .empty-golang-versions-files
+.PHONY: .empty-golang-versions-files
 
 verify-golang-versions:
 	@if [ -f "$(PERMANENT_TMP)/golang-versions" ]; then \
@@ -53,13 +56,3 @@ $(if $(1),$(call verify-Dockerfile-builder-golang-version,$(1))) \
 $(if $(wildcard ./.ci-operator.yaml),$(if $(shell grep 'build_root_image:' .ci-operator.yaml 2>/dev/null),$(call verify-buildroot-golang-version))) \
 $(if $(wildcard ./go.mod),$(call verify-go-mod-golang-version))
 endef
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)
-include $(addprefix $(self_dir), \
-	../../lib/tmp.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
@@ -1,7 +1,26 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)
 
-CONTROLLER_GEN_VERSION ?=v0.2.5
-CONTROLLER_GEN ?=$(PERMANENT_TMP_GOPATH)/bin/controller-gen
+# NOTE: The release binary specified here needs to be built properly so that
+# `--version` works correctly. Just using `go build` will result in it
+# reporting `(devel)`. To build for a given platform:
+# 	GOOS=xxx GOARCH=yyy go install sigs.k8s.io/controller-tools/cmd/controller-gen@$version
+# e.g.
+# 	GOOS=darwin GOARCH=amd64 go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0
+#
+# If GOOS and GOARCH match your current go env, this will install the binary at
+# 	$(go env GOPATH)/bin/controller-gen
+# Otherwise (when cross-compiling) it will install the binary at
+# 	$(go env GOPATH)/bin/${GOOS}_${GOARCH}/conroller-gen
+# e.g.
+# 	/home/efried/.gvm/pkgsets/go1.16/global/bin/darwin_amd64/controller-gen
+CONTROLLER_GEN_VERSION ?=v0.6.0
+CONTROLLER_GEN ?=$(PERMANENT_TMP_GOPATH)/bin/controller-gen-$(CONTROLLER_GEN_VERSION)
+ifneq "" "$(wildcard $(CONTROLLER_GEN))"
+_controller_gen_installed_version = $(shell $(CONTROLLER_GEN) --version | awk '{print $$2}')
+endif
 controller_gen_dir :=$(dir $(CONTROLLER_GEN))
 
 ensure-controller-gen:
@@ -12,20 +31,14 @@ ifeq "" "$(wildcard $(CONTROLLER_GEN))"
 	chmod +x '$(CONTROLLER_GEN)';
 else
 	$(info Using existing controller-gen from "$(CONTROLLER_GEN)")
+	@[[ "$(_controller_gen_installed_version)" == $(CONTROLLER_GEN_VERSION) ]] || \
+	echo "Warning: Installed controller-gen version $(_controller_gen_installed_version) does not match expected version $(CONTROLLER_GEN_VERSION)."
 endif
 .PHONY: ensure-controller-gen
 
 clean-controller-gen:
-	$(RM) '$(CONTROLLER_GEN)'
+	$(RM) $(controller_gen_dir)controller-gen*
 	if [ -d '$(controller_gen_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(controller_gen_dir)'; fi
 .PHONY: clean-controller-gen
 
 clean: clean-controller-gen
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-	../../lib/tmp.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/crd-schema-gen.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/crd-schema-gen.mk
@@ -1,4 +1,10 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+	../../targets/openshift/controller-gen.mk \
+	../../targets/openshift/yq.mk \
+	../../targets/openshift/yaml-patch.mk \
+)
 
 # $1 - crd file
 # $2 - patch file
@@ -76,15 +82,3 @@ verify: verify-generated
 define add-crd-gen
 $(eval $(call add-crd-gen-internal,$(1),$(2),$(3),$(4)))
 endef
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-	../../lib/tmp.mk \
-	../../targets/openshift/controller-gen.mk \
-	../../targets/openshift/yq.mk \
-    ../../targets/openshift/yaml-patch.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps-glide.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps-glide.mk
@@ -1,5 +1,4 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
-scripts_dir :=$(self_dir)/../../../scripts
+scripts_dir :=$(dir $(lastword $(MAKEFILE_LIST)))/../../../scripts
 
 # We need to force localle so different envs sort files the same way for recursive traversals
 deps_diff :=LC_COLLATE=C diff --no-dereference -N

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps-gomod.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps-gomod.mk
@@ -1,4 +1,6 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+)
 
 # We need to force localle so different envs sort files the same way for recursive traversals
 deps_diff :=LC_COLLATE=C diff --no-dereference -N
@@ -24,6 +26,7 @@ verify-deps:
 		echo "If this is an intentional change (a carry patch) please update the 'deps.diff' using 'make update-deps-overrides'." && \
 		false \
 	)
+	rm -rf $(tmp_dir)
 .PHONY: verify-deps
 
 update-deps-overrides: tmp_dir:=$(shell mktemp -d)
@@ -31,11 +34,3 @@ update-deps-overrides:
 	$(call restore-deps,$(tmp_dir))
 	cp "$(tmp_dir)"/{updated,current}/deps.diff
 .PHONY: update-deps-overrides
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps.mk
@@ -1,8 +1,10 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+# Use a unique variable name to avoid conflicting with generic
+# `self_dir` elsewhere.
+_self_dir_openshift_deps :=$(dir $(lastword $(MAKEFILE_LIST)))
 
-deps_gomod_mkfile := $(self_dir)/deps-gomod.mk
-deps_glide_mkfile := $(self_dir)/deps-glide.mk
-include $(addprefix $(self_dir), \
+deps_gomod_mkfile := $(_self_dir_openshift_deps)/deps-gomod.mk
+deps_glide_mkfile := $(_self_dir_openshift_deps)/deps-glide.mk
+include $(addprefix $(_self_dir_openshift_deps), \
 	../../lib/golang.mk \
 )
 

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/imagebuilder.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/imagebuilder.mk
@@ -1,0 +1,25 @@
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)
+
+IMAGEBUILDER_VERSION ?=1.2.1
+
+IMAGEBUILDER ?= $(shell which imagebuilder 2>/dev/null)
+ifneq "" "$(IMAGEBUILDER)"
+_imagebuilder_installed_version = $(shell $(IMAGEBUILDER) --version)
+endif
+
+# NOTE: We would like to
+#     go get github.com/openshift/imagebuilder/cmd/imagebuilder@v$(IMAGEBUILDER_VERSION)
+# ...but `go get` is too unreliable. So instead we use this to make the
+# "you don't have imagebuilder" error useful.
+ensure-imagebuilder:
+ifeq "" "$(IMAGEBUILDER)"
+	$(error imagebuilder not found! Get it with: `go get github.com/openshift/imagebuilder/cmd/imagebuilder@v$(IMAGEBUILDER_VERSION)`)
+else
+	$(info Using existing imagebuilder from $(IMAGEBUILDER))
+	@[[ "$(_imagebuilder_installed_version)" == $(IMAGEBUILDER_VERSION) ]] || \
+	echo "Warning: Installed imagebuilder version $(_imagebuilder_installed_version) does not match expected version $(IMAGEBUILDER_VERSION)."
+endif
+.PHONY: ensure-imagebuilder

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/images.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/images.mk
@@ -1,3 +1,7 @@
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	imagebuilder.mk \
+)
+
 # IMAGE_BUILD_EXTRA_FLAGS lets you add extra flags for imagebuilder
 # e.g. to mount secrets and repo information into base image like:
 # make images IMAGE_BUILD_EXTRA_FLAGS='-mount ~/projects/origin-repos/4.2/:/etc/yum.repos.d/'
@@ -9,7 +13,7 @@ IMAGE_BUILD_EXTRA_FLAGS ?=
 # $3 - Dockerfile path
 # $4 - context
 define build-image-internal
-image-$(1):
+image-$(1): ensure-imagebuilder
 	$(strip \
 		imagebuilder \
 		$(IMAGE_BUILD_DEFAULT_FLAGS) \

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/kustomize.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/kustomize.mk
@@ -1,0 +1,32 @@
+# We need to include this before we use PERMANENT_TMP_GOPATH
+# (indirectly) from ifeq.
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/tmp.mk \
+)
+
+KUSTOMIZE_VERSION ?= 4.1.3
+KUSTOMIZE ?= $(PERMANENT_TMP_GOPATH)/bin/kustomize-$(KUSTOMIZE_VERSION)
+kustomize_dir := $(dir $(KUSTOMIZE))
+
+ensure-kustomize:
+ifeq "" "$(wildcard $(KUSTOMIZE))"
+	$(info Installing kustomize into '$(KUSTOMIZE)')
+	mkdir -p '$(kustomize_dir)'
+	@# install_kustomize.sh lays down the binary as `kustomize`, and will
+	@# also fail if a file of that name already exists. Remove it for
+	@# backward compatibility (older b-m-gs used the raw file name).
+	rm -f $(kustomize_dir)/kustomize
+	@# NOTE: Pinning script to a tag rather than `master` for security reasons
+	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v$(KUSTOMIZE_VERSION)/hack/install_kustomize.sh"  | bash -s $(KUSTOMIZE_VERSION) $(kustomize_dir)
+	mv $(kustomize_dir)/kustomize $(KUSTOMIZE)
+else
+	$(info Using existing kustomize from "$(KUSTOMIZE)")
+endif
+.PHONY: ensure-kustomize
+
+clean-kustomize:
+	$(RM) $(kustomize_dir)kustomize*
+	if [ -d '$(kustomize_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(kustomize_dir)'; fi
+.PHONY: clean-kustomize
+
+clean: clean-kustomize

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/profile-manifests.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/profile-manifests.mk
@@ -1,12 +1,16 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../../lib/tmp.mk \
+	../yq.mk \
+	../yaml-patch.mk \
+)
 
 # Merge yaml patch using mikefarah/yq
 # $1 - patch file
 # $2 - manifest file
 # $3 - output file
 define patch-manifest-yq
-	$(YQ) m -x '$(2)' '$(1)' > '$(3)'
-	sed -i '$(3)' -e '1s/^/# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***\n/'
+	( echo '# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***'; \
+		$(YQ) m -x '$(2)' '$(1)' ) > '$(3)'
 
 endef
 
@@ -15,8 +19,8 @@ endef
 # $2 - manifest file
 # $3 - output file
 define patch-manifest-yaml-patch
-	$(YAML_PATCH) -o '$(1)' < '$(2)' > '$(3)'
-	sed -i '$(3)' -e '1s/^/# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***\n/'
+	( echo '# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***'; \
+		$(YAML_PATCH) -o '$(1)' < '$(2)' ) > '$(3)'
 
 endef
 
@@ -74,13 +78,3 @@ endef
 define add-profile-manifests
 $(eval $(call add-profile-manifests-internal,$(1),$(2),$(3)))
 endef
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../../lib/tmp.mk \
-	../yq.mk \
-	../yaml-patch.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/telepresence.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/telepresence.mk
@@ -1,5 +1,4 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
-scripts_dir :=$(shell realpath $(self_dir)../../../../scripts)
+scripts_dir :=$(shell realpath $(dir $(lastword $(MAKEFILE_LIST)))../../../../scripts)
 
 telepresence:
 	$(info Running operator locally against a remote cluster using telepresence (https://telepresence.io))

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/rpm.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/rpm.mk
@@ -1,3 +1,7 @@
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+)
+
 RPM_OUTPUT_DIR ?=_output
 RPM_TOPDIR ?=$(abspath ./)
 RPM_BUILDDIR ?=$(RPM_TOPDIR)
@@ -32,10 +36,3 @@ clean-rpms:
 .PHONY: clean-rpms
 
 clean: clean-rpms
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yaml-patch.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yaml-patch.mk
@@ -1,8 +1,13 @@
 ifndef _YAML_PATCH_MK_
 _YAML_PATCH_MK_ := defined
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
-YAML_PATCH ?=$(PERMANENT_TMP_GOPATH)/bin/yaml-patch
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)
+
+YAML_PATCH_VERSION ?=v0.0.10
+YAML_PATCH ?=$(PERMANENT_TMP_GOPATH)/bin/yaml-patch-$(YAML_PATCH_VERSION)
 yaml_patch_dir :=$(dir $(YAML_PATCH))
 
 
@@ -10,7 +15,7 @@ ensure-yaml-patch:
 ifeq "" "$(wildcard $(YAML_PATCH))"
 	$(info Installing yaml-patch into '$(YAML_PATCH)')
 	mkdir -p '$(yaml_patch_dir)'
-	curl -s -f -L https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_$(GOHOSTOS) -o '$(YAML_PATCH)'
+	curl -s -f -L https://github.com/krishicks/yaml-patch/releases/download/$(YAML_PATCH_VERSION)/yaml_patch_$(GOHOSTOS) -o '$(YAML_PATCH)'
 	chmod +x '$(YAML_PATCH)';
 else
 	$(info Using existing yaml-patch from "$(YAML_PATCH)")
@@ -18,18 +23,10 @@ endif
 .PHONY: ensure-yaml-patch
 
 clean-yaml-patch:
-	$(RM) '$(YAML_PATCH)'
+	$(RM) $(yaml_patch_dir)yaml-patch*
 	if [ -d '$(yaml_patch_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(yaml_patch_dir)'; fi
 .PHONY: clean-yaml-patch
 
 clean: clean-yaml-patch
 
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-	../../lib/tmp.mk \
-)
 endif

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
@@ -1,8 +1,13 @@
 ifndef _YQ_MK_
 _YQ_MK_ := defined
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
-YQ ?=$(PERMANENT_TMP_GOPATH)/bin/yq
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)
+
+YQ_VERSION ?=2.4.0
+YQ ?=$(PERMANENT_TMP_GOPATH)/bin/yq-$(YQ_VERSION)
 yq_dir :=$(dir $(YQ))
 
 
@@ -10,7 +15,7 @@ ensure-yq:
 ifeq "" "$(wildcard $(YQ))"
 	$(info Installing yq into '$(YQ)')
 	mkdir -p '$(yq_dir)'
-	curl -s -f -L https://github.com/mikefarah/yq/releases/download/2.4.0/yq_$(GOHOSTOS)_$(GOHOSTARCH) -o '$(YQ)'
+	curl -s -f -L https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(GOHOSTOS)_$(GOHOSTARCH) -o '$(YQ)'
 	chmod +x '$(YQ)';
 else
 	$(info Using existing yq from "$(YQ)")
@@ -18,18 +23,10 @@ endif
 .PHONY: ensure-yq
 
 clean-yq:
-	$(RM) '$(YQ)'
+	$(RM) $(yq_dir)yq*
 	if [ -d '$(yq_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(yq_dir)'; fi
 .PHONY: clean-yq
 
 clean: clean-yq
 
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-	../../lib/tmp.mk \
-)
 endif

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -249,7 +249,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
+# github.com/openshift/build-machinery-go v0.0.0-20210922160744-a9caf93aef90
 ## explicit
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
Update openshift/build-machinery-go to the latest commit, which is a fix
required by our CI to allow parsing Go 1.16 version formatting. This is
part of unblocking golangci-lint tests.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>