### PR TITLE
Move helpers.ApplyManifestWork to manifestwork.Apply

### DIFF
--- a/pkg/cloud/manifestwork/machineset.go
+++ b/pkg/cloud/manifestwork/machineset.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/open-cluster-management/submariner-addon/pkg/helpers"
+	"github.com/open-cluster-management/submariner-addon/pkg/manifestwork"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/cloud-prepare/pkg/ocp"
@@ -70,7 +70,7 @@ func (msd *manifestWorkMachineSetDeployer) Deploy(machineSet *unstructured.Unstr
 	}
 	manifests = append(manifests, workv1.Manifest{RawExtension: runtime.RawExtension{Raw: machineSetJson}})
 
-	return helpers.ApplyManifestWork(context.TODO(), msd.client, &workv1.ManifestWork{
+	return manifestwork.Apply(context.TODO(), msd.client, &workv1.ManifestWork{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      msd.workName,

--- a/pkg/hub/submarineragent/controller.go
+++ b/pkg/hub/submarineragent/controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
+	"github.com/open-cluster-management/submariner-addon/pkg/manifestwork"
 
 	configv1alpha1 "github.com/open-cluster-management/submariner-addon/pkg/apis/submarinerconfig/v1alpha1"
 	configclient "github.com/open-cluster-management/submariner-addon/pkg/client/submarinerconfig/clientset/versioned"
@@ -477,7 +478,7 @@ func (c *submarinerAgentController) deploySubmarinerAgent(
 	if err != nil {
 		return err
 	}
-	if err := helpers.ApplyManifestWork(ctx, c.manifestWorkClient, operatorManifestWork, c.eventRecorder); err != nil {
+	if err := manifestwork.Apply(ctx, c.manifestWorkClient, operatorManifestWork, c.eventRecorder); err != nil {
 		return err
 	}
 

--- a/pkg/manifestwork/apply.go
+++ b/pkg/manifestwork/apply.go
@@ -1,0 +1,41 @@
+package manifestwork
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	workclient "open-cluster-management.io/api/client/work/clientset/versioned"
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+func Apply(ctx context.Context, client workclient.Interface, toApply *workv1.ManifestWork, recorder events.Recorder) error {
+	resourceInterface := &resource.InterfaceFuncs{
+		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.WorkV1().ManifestWorks(toApply.Namespace).Get(ctx, toApply.Name, options)
+		},
+		CreateFunc: func(ctx context.Context, obj runtime.Object, options metav1.CreateOptions) (runtime.Object, error) {
+			return client.WorkV1().ManifestWorks(toApply.Namespace).Create(ctx, obj.(*workv1.ManifestWork), options)
+		},
+		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+			return client.WorkV1().ManifestWorks(toApply.Namespace).Update(ctx, obj.(*workv1.ManifestWork), options)
+		},
+	}
+
+	result, err := util.CreateOrUpdate(ctx, resourceInterface, toApply, func(existing runtime.Object) (runtime.Object, error) {
+		existing.(*workv1.ManifestWork).Spec = toApply.Spec
+		return existing, nil
+	})
+
+	if result == util.OperationResultCreated {
+		recorder.Event("ManifestWorkApplied", fmt.Sprintf("manifestwork %s/%s was created", toApply.Namespace, toApply.Name))
+	} else if result == util.OperationResultUpdated {
+		recorder.Event("ManifestWorkApplied", fmt.Sprintf("manifestwork %s/%s was updated", toApply.Namespace, toApply.Name))
+	}
+
+	return err
+}

--- a/pkg/manifestwork/apply_test.go
+++ b/pkg/manifestwork/apply_test.go
@@ -1,0 +1,158 @@
+package manifestwork_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/open-cluster-management/submariner-addon/pkg/helpers/testing"
+	"github.com/open-cluster-management/submariner-addon/pkg/manifestwork"
+	"github.com/openshift/library-go/pkg/operator/events"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"open-cluster-management.io/api/client/work/clientset/versioned/fake"
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+var _ = Describe("Apply", func() {
+	var (
+		work          *workv1.ManifestWork
+		existingWorks []runtime.Object
+		workClient    *fake.Clientset
+	)
+
+	BeforeEach(func() {
+		existingWorks = []runtime.Object{}
+
+		work = &workv1.ManifestWork{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test-ns",
+			},
+			Spec: workv1.ManifestWorkSpec{
+				Workload: workv1.ManifestsTemplate{
+					Manifests: []workv1.Manifest{
+						{
+							RawExtension: runtime.RawExtension{
+								Raw: []byte("test-data"),
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		workClient = fake.NewSimpleClientset(existingWorks...)
+	})
+
+	doApply := func() error {
+		return manifestwork.Apply(context.TODO(), workClient, work, events.NewLoggingEventRecorder("test"))
+	}
+
+	ensureWork := func() {
+		actual, err := workClient.WorkV1().ManifestWorks(work.Namespace).Get(context.TODO(), work.Name, metav1.GetOptions{})
+		Expect(err).To(Succeed())
+		Expect(actual.Spec).To(Equal(work.Spec))
+	}
+
+	When("the Work doesn't exist", func() {
+		It("should create it", func() {
+			Expect(doApply()).To(Succeed())
+			ensureWork()
+		})
+
+		Context("and creation fails", func() {
+			JustBeforeEach(func() {
+				testing.FailOnAction(&workClient.Fake, "manifestworks", "create", nil, false)
+			})
+
+			It("should return an error", func() {
+				Expect(doApply()).ToNot(Succeed())
+			})
+		})
+	})
+
+	When("the Work exists", func() {
+		BeforeEach(func() {
+			existingWorks = []runtime.Object{work.DeepCopy()}
+		})
+
+		Context("and the workload manifest has changed", func() {
+			BeforeEach(func() {
+				work.Spec.Workload.Manifests[0].RawExtension.Raw = []byte("test-data-updated")
+			})
+
+			It("should update it", func() {
+				Expect(doApply()).To(Succeed())
+				ensureWork()
+			})
+
+			Context("and update fails", func() {
+				JustBeforeEach(func() {
+					testing.FailOnAction(&workClient.Fake, "manifestworks", "update", nil, false)
+				})
+
+				It("should return an error", func() {
+					Expect(doApply()).ToNot(Succeed())
+				})
+			})
+
+			Context("and update initially fails with a conflict error", func() {
+				BeforeEach(func() {
+					testing.ConflictOnUpdateReactor(&workClient.Fake, "manifestworks")
+				})
+
+				It("should eventually update it", func() {
+					Expect(doApply()).To(Succeed())
+					ensureWork()
+				})
+			})
+		})
+
+		Context("and a workload manifest was added", func() {
+			BeforeEach(func() {
+				work.Spec.Workload.Manifests = append(work.Spec.Workload.Manifests, workv1.Manifest{
+					RawExtension: runtime.RawExtension{
+						Raw: []byte("test-data2"),
+					},
+				})
+			})
+
+			It("should update it", func() {
+				Expect(doApply()).To(Succeed())
+				ensureWork()
+			})
+
+			Context("and update fails", func() {
+				JustBeforeEach(func() {
+					testing.FailOnAction(&workClient.Fake, "manifestworks", "update", nil, false)
+				})
+
+				It("should return an error", func() {
+					Expect(doApply()).ToNot(Succeed())
+				})
+			})
+
+			Context("and update initially fails with a conflict error", func() {
+				BeforeEach(func() {
+					testing.ConflictOnUpdateReactor(&workClient.Fake, "manifestworks")
+				})
+
+				It("should eventually update it", func() {
+					Expect(doApply()).To(Succeed())
+					ensureWork()
+				})
+			})
+		})
+
+		Context("and the Work Spec has not changed", func() {
+			It("should not update it", func() {
+				Expect(doApply()).To(Succeed())
+				testing.EnsureNoActionsForResource(&workClient.Fake, "manifestworks", "update")
+			})
+		})
+	})
+})

--- a/pkg/manifestwork/manifestwork_suite_test.go
+++ b/pkg/manifestwork/manifestwork_suite_test.go
@@ -1,0 +1,13 @@
+package manifestwork_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestManifestwork(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Manifestwork Suite")
+}


### PR DESCRIPTION
It's better to avoid lumping unrelated functions into util or helpers packages so move this function to its own package.

Also modified it to use admiral's `CreateOrUpdate`.
