### PR TITLE
Move to v1 for CRDs

### DIFF
--- a/pkg/hub/submarinerbroker/manifests/submariner.io_clusters_crd.yaml
+++ b/pkg/hub/submarinerbroker/manifests/submariner.io_clusters_crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusters.submariner.io
   ownerReferences:
-  - apiVersion: apiextensions.k8s.io/v1beta1
+  - apiVersion: apiextensions.k8s.io/v1
     controller: true
     blockOwnerDeletion: true
     kind: CustomResourceDefinition

--- a/pkg/hub/submarinerbroker/manifests/submariner.io_endpoints_crd.yaml
+++ b/pkg/hub/submarinerbroker/manifests/submariner.io_endpoints_crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: endpoints.submariner.io
   ownerReferences:
-  - apiVersion: apiextensions.k8s.io/v1beta1
+  - apiVersion: apiextensions.k8s.io/v1
     controller: true
     blockOwnerDeletion: true
     kind: CustomResourceDefinition

--- a/pkg/hub/submarinerbroker/manifests/submariner.io_gateways_crd.yaml
+++ b/pkg/hub/submarinerbroker/manifests/submariner.io_gateways_crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: gateways.submariner.io
   ownerReferences:
-  - apiVersion: apiextensions.k8s.io/v1beta1
+  - apiVersion: apiextensions.k8s.io/v1
     controller: true
     blockOwnerDeletion: true
     kind: CustomResourceDefinition

--- a/pkg/hub/submarinerbroker/manifests/submariner.io_lighthouse.serviceimports_crd.yaml
+++ b/pkg/hub/submarinerbroker/manifests/submariner.io_lighthouse.serviceimports_crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serviceimports.lighthouse.submariner.io
   ownerReferences:
-  - apiVersion: apiextensions.k8s.io/v1beta1
+  - apiVersion: apiextensions.k8s.io/v1
     controller: true
     blockOwnerDeletion: true
     kind: CustomResourceDefinition

--- a/pkg/hub/submarinerbroker/manifests/x-k8s.io_multicluster.serviceimports_crd.yaml
+++ b/pkg/hub/submarinerbroker/manifests/x-k8s.io_multicluster.serviceimports_crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serviceimports.multicluster.x-k8s.io
   ownerReferences:
-  - apiVersion: apiextensions.k8s.io/v1beta1
+  - apiVersion: apiextensions.k8s.io/v1
     controller: true
     blockOwnerDeletion: true
     kind: CustomResourceDefinition


### PR DESCRIPTION
...instead of v1beta1 which is deprecated from
k8s v1.16+ and unavailable in v1.22+

Signed-Off-By: Janki Chhatbar <jchhatba@redhat.com>