### PR TITLE
Ignore pkg/cloud dir in Go linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,7 @@
 ---
+run:
+  skip-dirs:
+    - pkg/cloud
 linters-settings:
   gocritic:
     enabled-tags:


### PR DESCRIPTION
All the code in this package will be removed, or moved to cloud-prepare.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>