### PR TITLE
Check for nil config.Spec.CredentialsSecret

### DIFF
--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -497,6 +497,11 @@ func TestSyncSubmarinerConfig(t *testing.T) {
 						DeletionTimestamp: &now,
 						Finalizers:        []string{"submarineraddon.open-cluster-management.io/config-cleanup"},
 					},
+					Status: configv1alpha1.SubmarinerConfigStatus{
+						ManagedClusterInfo: configv1alpha1.ManagedClusterInfo{
+							Platform: "GCP",
+						},
+					},
 				},
 			},
 			clusters: []runtime.Object{


### PR DESCRIPTION
...in `cloud.ProviderFactory` and return a no-op `Provider`. Also return no-op if there's no provider for the platform. These conditions indicate that cloud preparation isn't necessary. Adjust callers appropriately.
