### PR TITLE
Fix condition status check in submarinerConfigController

### DIFF
--- a/pkg/spoke/submarineragent/config_controller.go
+++ b/pkg/spoke/submarineragent/config_controller.go
@@ -180,7 +180,7 @@ func (c *submarinerConfigController) sync(ctx context.Context, syncCtx factory.S
 	}
 
 	if config.Status.ManagedClusterInfo.Platform == "GCP" {
-		if meta.IsStatusConditionFalse(config.Status.Conditions, configv1alpha1.SubmarinerConfigConditionEnvPrepared) {
+		if !meta.IsStatusConditionTrue(config.Status.Conditions, configv1alpha1.SubmarinerConfigConditionEnvPrepared) {
 			errs := []error{}
 
 			cloudProvider, preparedErr := c.cloudProviderFactory.Get(config.Status.ManagedClusterInfo, config, c.eventRecorder)


### PR DESCRIPTION
`meta.IsStatusConditionFalse` only returns true if the condition type is present and set to `False`. So if it's not present it returns false. Use `!meta.IsStatusConditionTrue ` which does what we want.

