### PR TITLE
Manage v1 CRDs in the broker CRD controller

### DIFF
--- a/pkg/hub/manager.go
+++ b/pkg/hub/manager.go
@@ -126,7 +126,7 @@ func (o *AddOnOptions) RunControllerManager(ctx context.Context, controllerConte
 
 	submarinerBrokerCRDsController := submarinerbroker.NewSubmarinerBrokerCRDsController(
 		apiExtensionClient,
-		apiExtensionsInformers.Apiextensions().V1beta1().CustomResourceDefinitions(),
+		apiExtensionsInformers.Apiextensions().V1().CustomResourceDefinitions(),
 		controllerContext.EventRecorder,
 	)
 

--- a/pkg/hub/submarinerbroker/brokerCRDsController.go
+++ b/pkg/hub/submarinerbroker/brokerCRDsController.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorhelpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -67,7 +67,7 @@ func (c *submarinerBrokerCRDsController) sync(ctx context.Context, syncCtx facto
 		return nil
 	}
 
-	configCRD, err := c.crdClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(ctx, crdName, v1.GetOptions{})
+	configCRD, err := c.crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, v1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil
 	}

--- a/pkg/hub/submarinerbroker/brokerCRDsController_test.go
+++ b/pkg/hub/submarinerbroker/brokerCRDsController_test.go
@@ -2,11 +2,12 @@ package submarinerbroker
 
 import (
 	"context"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	fakeapiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	"testing"
 	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	fakeapiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 
 	testinghelpers "github.com/open-cluster-management/submariner-addon/pkg/helpers/testing"
 
@@ -17,8 +18,8 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 )
 
-func newSubmarinerConfigCRD() *apiextensionsv1beta1.CustomResourceDefinition {
-	return &apiextensionsv1beta1.CustomResourceDefinition{
+func newSubmarinerConfigCRD() *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: configCRDName,
 		},


### PR DESCRIPTION
Since we now ship v1 CRDs, we shouldn't care about v1beta1 CRDs.

Fixes: https://github.com/open-cluster-management/backlog/issues/16660
Signed-off-by: Stephen Kitt <skitt@redhat.com>