### PR TITLE
Avoid specifying null creation timestamps

### DIFF
--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -5,7 +5,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
   name: submarinerconfigs.submarineraddon.open-cluster-management.io
 spec:
   group: submarineraddon.open-cluster-management.io

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
   name: submarinerconfigs.submarineraddon.open-cluster-management.io
 spec:
   group: submarineraddon.open-cluster-management.io

--- a/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
+++ b/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
@@ -5,7 +5,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
   name: submarinerconfigs.submarineraddon.open-cluster-management.io
 spec:
   group: submarineraddon.open-cluster-management.io

--- a/test/integration/crds/submariner/submariner.io_submariners.yaml
+++ b/test/integration/crds/submariner/submariner.io_submariners.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
   name: submariners.submariner.io
 spec:
   group: submariner.io


### PR DESCRIPTION
These are preserved as-is in created resources, and cause errors when
editing the resources later on.

Signed-off-by: Stephen Kitt <skitt@redhat.com>