### PR TITLE
Enable golangci-lint gocritic assignOp linter, fix errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters-settings:
     disabled-checks:
       - ifElseChain
       - unnamedResult
-      - assignOp
       - commentFormatting
       - deferUnlambda
       - emptyStringTest

--- a/pkg/spoke/submarineragent/config_controller.go
+++ b/pkg/spoke/submarineragent/config_controller.go
@@ -494,10 +494,10 @@ func (c *submarinerConfigController) findGatewaysWithZone(expected int, zoneLabe
 			}
 
 			gateways = append(gateways, nodes[nodeIndex])
-			count = count + 1
+			count++
 		}
 
-		nodeIndex = nodeIndex + 1
+		nodeIndex++
 	}
 
 	return gateways, nil


### PR DESCRIPTION
Depends on https://github.com/open-cluster-management/submariner-addon/pull/179.