### PR TITLE
Enable golangci-lint gocyclo linter, fix errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters-settings:
       - performance
       - style
   gocyclo:
-    min-complexity: 20
+    min-complexity: 15
   govet:
     enable:
       - fieldalignment
@@ -21,7 +21,7 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    # - cyclop # TODO: Do we want this?
+    # - cyclop # This is equivalent to gocyclo
     - deadcode
     - depguard
     - dogsled
@@ -42,7 +42,7 @@ linters:
     # - gocognit # Actually runs revive linter
     - goconst
     - gocritic
-    # - gocyclo # TODO: Do we want this?
+    - gocyclo
     # - godot # TODO: Do we want this?
     # - godox # TODO: Do we want this?
     # - goerr113 # TODO: Fix and enable

--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -142,8 +142,8 @@ func TestSyncManagedCluster(t *testing.T) {
 			kubeObjs: []runtime.Object{},
 			validateActions: func(t *testing.T, kubeActions, clusterActions, workActions, addonActions []clienttesting.Action) {
 				testinghelpers.AssertNoActions(t, kubeActions)
-				testinghelpers.AssertActions(t, clusterActions, "update")
-				managedCluster := clusterActions[0].(clienttesting.UpdateActionImpl).Object
+				testinghelpers.AssertActions(t, clusterActions, "get", "update")
+				managedCluster := clusterActions[1].(clienttesting.UpdateActionImpl).Object
 				testinghelpers.AssertFinalizers(t, managedCluster, []string{agentFinalizer})
 				testinghelpers.AssertNoActions(t, workActions)
 				testinghelpers.AssertNoActions(t, addonActions)
@@ -169,8 +169,8 @@ func TestSyncManagedCluster(t *testing.T) {
 				testinghelpers.AssertNoActions(t, kubeActions)
 				testinghelpers.AssertNoActions(t, clusterActions)
 				testinghelpers.AssertNoActions(t, workActions)
-				testinghelpers.AssertActions(t, addonActions, "update")
-				addOn := addonActions[0].(clienttesting.UpdateActionImpl).Object
+				testinghelpers.AssertActions(t, addonActions, "get", "update")
+				addOn := addonActions[1].(clienttesting.UpdateActionImpl).Object
 				testinghelpers.AssertFinalizers(t, addOn, []string{addOnFinalizer})
 			},
 		},

--- a/pkg/resource/resource_interface.go
+++ b/pkg/resource/resource_interface.go
@@ -6,20 +6,58 @@ import (
 	"github.com/submariner-io/admiral/pkg/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	clusterClient "open-cluster-management.io/api/client/cluster/clientset/versioned/typed/cluster/v1beta1"
-	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	addonV1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	addonV1alpha1Client "open-cluster-management.io/api/client/addon/clientset/versioned/typed/addon/v1alpha1"
+	clusterV1Client "open-cluster-management.io/api/client/cluster/clientset/versioned/typed/cluster/v1"
+	clusterV1beta1Client "open-cluster-management.io/api/client/cluster/clientset/versioned/typed/cluster/v1beta1"
+	clusterV1 "open-cluster-management.io/api/cluster/v1"
+	clusterV1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 )
 
-func ForManagedClusterSet(client clusterClient.ManagedClusterSetInterface) resource.Interface {
+func ForManagedClusterSet(client clusterV1beta1Client.ManagedClusterSetInterface) resource.Interface {
 	return &resource.InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
 			return client.Get(ctx, name, options)
 		},
 		CreateFunc: func(ctx context.Context, obj runtime.Object, options metav1.CreateOptions) (runtime.Object, error) {
-			return client.Create(ctx, obj.(*clusterv1beta1.ManagedClusterSet), options)
+			return client.Create(ctx, obj.(*clusterV1beta1.ManagedClusterSet), options)
 		},
 		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
-			return client.Update(ctx, obj.(*clusterv1beta1.ManagedClusterSet), options)
+			return client.Update(ctx, obj.(*clusterV1beta1.ManagedClusterSet), options)
+		},
+		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+			return client.Delete(ctx, name, options)
+		},
+	}
+}
+
+func ForManagedCluster(client clusterV1Client.ManagedClusterInterface) resource.Interface {
+	return &resource.InterfaceFuncs{
+		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.Get(ctx, name, options)
+		},
+		CreateFunc: func(ctx context.Context, obj runtime.Object, options metav1.CreateOptions) (runtime.Object, error) {
+			return client.Create(ctx, obj.(*clusterV1.ManagedCluster), options)
+		},
+		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+			return client.Update(ctx, obj.(*clusterV1.ManagedCluster), options)
+		},
+		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+			return client.Delete(ctx, name, options)
+		},
+	}
+}
+
+func ForAddon(client addonV1alpha1Client.ManagedClusterAddOnInterface) resource.Interface {
+	return &resource.InterfaceFuncs{
+		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
+			return client.Get(ctx, name, options)
+		},
+		CreateFunc: func(ctx context.Context, obj runtime.Object, options metav1.CreateOptions) (runtime.Object, error) {
+			return client.Create(ctx, obj.(*addonV1alpha1.ManagedClusterAddOn), options)
+		},
+		UpdateFunc: func(ctx context.Context, obj runtime.Object, options metav1.UpdateOptions) (runtime.Object, error) {
+			return client.Update(ctx, obj.(*addonV1alpha1.ManagedClusterAddOn), options)
 		},
 		DeleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions) error {
 			return client.Delete(ctx, name, options)


### PR DESCRIPTION
The existing **min-complexity** setting was 20 which yielded one function in violation. Generally 10 is considered within the cyclomatic complexity acceptable range but I think 15 is reasonable. Only 4 functions required some refactoring:

```
pkg/spoke/submarineragent/deployment_controller.go:61:1: cyclomatic complexity 24 of func `(*deploymentStatusController).sync` is high (> 15) (gocyclo)
func (c *deploymentStatusController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
^
pkg/spoke/submarineragent/config_controller.go:115:1: cyclomatic complexity 20 of func `(*submarinerConfigController).sync` is high (> 15) (gocyclo)
func (c *submarinerConfigController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
^
pkg/hub/submarineragent/controller.go:261:1: cyclomatic complexity 16 of func `(*submarinerAgentController).syncManagedCluster` is high (> 15) (gocyclo)
func (c *submarinerAgentController) syncManagedCluster(
^
pkg/hub/submarineragent/controller.go:176:1: cyclomatic complexity 16 of func `(*submarinerAgentController).sync` is high (> 15) (gocyclo)
func (c *submarinerAgentController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
^
```