### PR TITLE
Enable golangci-lint 'dupl' linter, fix errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,7 @@ linters:
     - deadcode
     - depguard
     - dogsled
-    # - dupl # TODO: Fix and enable
+    - dupl
     - durationcheck
     - errcheck
     # - errname # Not supported with our version of golangci-lint

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -24,6 +24,7 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
+//nolint:dupl // These tests will either be removed or converted to Gingko.
 func TestUpdateStatusCondition(t *testing.T) {
 	nowish := metav1.Now()
 	beforeish := metav1.Time{Time: nowish.Add(-10 * time.Second)}
@@ -120,6 +121,7 @@ func TestUpdateStatusCondition(t *testing.T) {
 	}
 }
 
+//nolint:dupl // These tests will either be removed or converted to Gingko.
 func TestUpdateManagedClusterAddOnStatus(t *testing.T) {
 	nowish := metav1.Now()
 	beforeish := metav1.Time{Time: nowish.Add(-10 * time.Second)}

--- a/pkg/resource/resource_interface.go
+++ b/pkg/resource/resource_interface.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Lines are similar but not duplicated and can't be refactored to avloid this error.
 package resource
 
 import (


### PR DESCRIPTION
Signed-off-by: Tom Pantelis <tompantelis@gmail.com>