### PR TITLE
backport: Add RBAC permission endpointslices/restricted in broker roles

### DIFF
--- a/pkg/hub/submarinerbroker/manifests/broker-cluster-role.yaml
+++ b/pkg/hub/submarinerbroker/manifests/broker-cluster-role.yaml
@@ -14,5 +14,5 @@ rules:
   resources: ["*"]
   verbs: ["create", "get", "list", "watch", "patch", "update", "delete"]
 - apiGroups: ["discovery.k8s.io"]
-  resources: ["endpointslices"]
+  resources: ["endpointslices", "endpointslices/restricted"]
   verbs: ["create", "get", "list", "watch","patch", "update", "delete"]


### PR DESCRIPTION
- Manage v1 CRDs in the broker CRD controller (#163)
- Fix condition status check in submarinerConfigController (#164)
- Add RBAC permission endpointslices/restricted in broker roles
