### PR TITLE
Move SubmarinerConfig update from submarinerbrokerinfo.Get to caller

### DIFF
--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -88,6 +88,22 @@ var _ = Describe("Controller", func() {
 
 				It("should deploy the submariner ManifestWork with the SubmarinerConfig overrides", func() {
 					t.awaitManifestWork()
+
+					expCond := &metav1.Condition{
+						Type:   configv1alpha1.SubmarinerConfigConditionApplied,
+						Status: metav1.ConditionTrue,
+						Reason: "SubmarinerConfigApplied",
+					}
+
+					test.AwaitStatusCondition(expCond, func() ([]metav1.Condition, error) {
+						config, err := t.configClient.SubmarineraddonV1alpha1().SubmarinerConfigs(clusterName).Get(context.TODO(),
+							helpers.SubmarinerConfigName, metav1.GetOptions{})
+						if err != nil {
+							return nil, err
+						}
+
+						return config.Status.Conditions, nil
+					})
 				})
 			})
 

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
@@ -7,11 +7,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	configv1alpha1 "github.com/open-cluster-management/submariner-addon/pkg/apis/submarinerconfig/v1alpha1"
-	configclient "github.com/open-cluster-management/submariner-addon/pkg/client/submarinerconfig/clientset/versioned"
-	fakeconfigclient "github.com/open-cluster-management/submariner-addon/pkg/client/submarinerconfig/clientset/versioned/fake"
 	"github.com/open-cluster-management/submariner-addon/pkg/hub/submarinerbrokerinfo"
 	apiconfigv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/library-go/pkg/operator/events"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -38,7 +35,6 @@ func TestSubmarinerBrokerInfo(t *testing.T) {
 
 var _ = Describe("Function Get", func() {
 	var (
-		configClient          configclient.Interface
 		installationNamespace string
 		submarinerConfig      *configv1alpha1.SubmarinerConfig
 		infrastructure        *unstructured.Unstructured
@@ -102,17 +98,9 @@ var _ = Describe("Function Get", func() {
 	})
 
 	JustBeforeEach(func() {
-		if submarinerConfig != nil {
-			configClient = fakeconfigclient.NewSimpleClientset(submarinerConfig)
-		} else {
-			configClient = fakeconfigclient.NewSimpleClientset()
-		}
-
 		brokerInfo, err = submarinerbrokerinfo.Get(
 			kubefake.NewSimpleClientset(kubeObjs...),
 			dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), dynamicObjs...),
-			configClient,
-			events.NewLoggingEventRecorder("test"),
 			clusterName,
 			brokerNamespace,
 			submarinerConfig,


### PR DESCRIPTION
The purpose of `submarinerbrokerinfo.Get` is to retrieve the broker info so it really shouldn't have the side effect of updating the passed `SubmarinerConfig` condition status.