### PR TITLE
Add image override for networkPluginSyncer

### DIFF
--- a/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/config/crds/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -158,6 +158,10 @@ spec:
                     description: SubmarinerImagePullSpec represents the desired image
                       of submariner.
                     type: string
+                  submarinerNetworkPluginSyncerImagePullSpec:
+                    description: SubmarinerNetworkPluginSyncerImagePullSpec represents
+                      the desired image of the submariner networkplugin syncer.
+                    type: string
                   submarinerRouteAgentImagePullSpec:
                     description: SubmarinerRouteAgentImagePullSpec represents the
                       desired image of the submariner route agent.

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -114,6 +114,10 @@ spec:
                   submarinerImagePullSpec:
                     description: SubmarinerImagePullSpec represents the desired image of submariner.
                     type: string
+                  submarinerNetworkPluginSyncerImagePullSpec:
+                    description: SubmarinerNetworkPluginSyncerImagePullSpec represents
+                      the desired image of the submariner networkplugin syncer.
+                    type: string
                   submarinerRouteAgentImagePullSpec:
                     description: SubmarinerRouteAgentImagePullSpec represents the desired image of the submariner route agent.
                     type: string

--- a/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
+++ b/pkg/apis/submarinerconfig/v1alpha1/0000_00_submarineraddon.open-cluster-management.io_submarinerconfigs.crd.yaml
@@ -158,6 +158,10 @@ spec:
                     description: SubmarinerImagePullSpec represents the desired image
                       of submariner.
                     type: string
+                  submarinerNetworkPluginSyncerImagePullSpec:
+                    description: SubmarinerNetworkPluginSyncerImagePullSpec represents
+                      the desired image of the submariner networkplugin syncer.
+                    type: string
                   submarinerRouteAgentImagePullSpec:
                     description: SubmarinerRouteAgentImagePullSpec represents the
                       desired image of the submariner route agent.

--- a/pkg/apis/submarinerconfig/v1alpha1/types.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/types.go
@@ -132,6 +132,10 @@ type SubmarinerImagePullSpecs struct {
 	// SubmarinerGlobalnetImagePullSpec represents the desired image of the submariner globalnet.
 	// +optional
 	SubmarinerGlobalnetImagePullSpec string `json:"submarinerGlobalnetImagePullSpec,omitempty"`
+
+	// SubmarinerNetworkPluginSyncerImagePullSpec represents the desired image of the submariner networkplugin syncer.
+	// +optional
+	SubmarinerNetworkPluginSyncerImagePullSpec string `json:"submarinerNetworkPluginSyncerImagePullSpec,omitempty"`
 }
 
 type GatewayConfig struct {

--- a/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/pkg/apis/submarinerconfig/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -117,11 +117,12 @@ func (SubmarinerConfigStatus) SwaggerDoc() map[string]string {
 }
 
 var map_SubmarinerImagePullSpecs = map[string]string{
-	"submarinerImagePullSpec":           "SubmarinerImagePullSpec represents the desired image of submariner.",
-	"lighthouseAgentImagePullSpec":      "LighthouseAgentImagePullSpec represents the desired image of the lighthouse agent.",
-	"lighthouseCoreDNSImagePullSpec":    "LighthouseCoreDNSImagePullSpec represents the desired image of lighthouse coredns.",
-	"submarinerRouteAgentImagePullSpec": "SubmarinerRouteAgentImagePullSpec represents the desired image of the submariner route agent.",
-	"submarinerGlobalnetImagePullSpec":  "SubmarinerGlobalnetImagePullSpec represents the desired image of the submariner globalnet.",
+	"submarinerImagePullSpec":                    "SubmarinerImagePullSpec represents the desired image of submariner.",
+	"lighthouseAgentImagePullSpec":               "LighthouseAgentImagePullSpec represents the desired image of the lighthouse agent.",
+	"lighthouseCoreDNSImagePullSpec":             "LighthouseCoreDNSImagePullSpec represents the desired image of lighthouse coredns.",
+	"submarinerRouteAgentImagePullSpec":          "SubmarinerRouteAgentImagePullSpec represents the desired image of the submariner route agent.",
+	"submarinerGlobalnetImagePullSpec":           "SubmarinerGlobalnetImagePullSpec represents the desired image of the submariner globalnet.",
+	"submarinerNetworkPluginSyncerImagePullSpec": "SubmarinerNetworkPluginSyncerImagePullSpec represents the desired image of the submariner networkplugin syncer.",
 }
 
 func (SubmarinerImagePullSpecs) SwaggerDoc() map[string]string {

--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -33,6 +33,9 @@ spec:
     {{- if .SubmarinerGlobalnetImage }}
     submariner-globalnet: {{ .SubmarinerGlobalnetImage }}
     {{- end}}
+    {{- if .SubmarinerNetworkPluginSyncerImage }}
+    submariner-networkplugin-syncer: {{ .SubmarinerNetworkPluginSyncerImage }}
+    {{- end}}
     {{- if .LighthouseAgentImage }}
     lighthouse-agent: {{ .LighthouseAgentImage }}
     {{- end}}

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -54,31 +54,32 @@ var (
 )
 
 type SubmarinerBrokerInfo struct {
-	NATEnabled                bool
-	LoadBalancerEnabled       bool
-	IPSecNATTPort             int
-	InstallationNamespace     string
-	InstallPlanApproval       string
-	BrokerAPIServer           string
-	BrokerNamespace           string
-	BrokerToken               string
-	BrokerCA                  string
-	IPSecPSK                  string
-	CableDriver               string
-	ClusterName               string
-	ClusterCIDR               string
-	GlobalCIDR                string
-	ServiceCIDR               string
-	CatalogChannel            string
-	CatalogName               string
-	CatalogSource             string
-	CatalogSourceNamespace    string
-	CatalogStartingCSV        string
-	SubmarinerGatewayImage    string
-	SubmarinerRouteAgentImage string
-	SubmarinerGlobalnetImage  string
-	LighthouseAgentImage      string
-	LighthouseCoreDNSImage    string
+	NATEnabled                         bool
+	LoadBalancerEnabled                bool
+	IPSecNATTPort                      int
+	InstallationNamespace              string
+	InstallPlanApproval                string
+	BrokerAPIServer                    string
+	BrokerNamespace                    string
+	BrokerToken                        string
+	BrokerCA                           string
+	IPSecPSK                           string
+	CableDriver                        string
+	ClusterName                        string
+	ClusterCIDR                        string
+	GlobalCIDR                         string
+	ServiceCIDR                        string
+	CatalogChannel                     string
+	CatalogName                        string
+	CatalogSource                      string
+	CatalogSourceNamespace             string
+	CatalogStartingCSV                 string
+	SubmarinerGatewayImage             string
+	SubmarinerRouteAgentImage          string
+	SubmarinerGlobalnetImage           string
+	SubmarinerNetworkPluginSyncerImage string
+	LighthouseAgentImage               string
+	LighthouseCoreDNSImage             string
 }
 
 // Get retrieves submariner broker information consolidated with hub information.
@@ -233,6 +234,10 @@ func applySubmarinerImageConfig(brokerInfo *SubmarinerBrokerInfo, submarinerConf
 
 	if submarinerConfig.Spec.ImagePullSpecs.SubmarinerGlobalnetImagePullSpec != "" {
 		brokerInfo.SubmarinerGlobalnetImage = submarinerConfig.Spec.ImagePullSpecs.SubmarinerGlobalnetImagePullSpec
+	}
+
+	if submarinerConfig.Spec.ImagePullSpecs.SubmarinerNetworkPluginSyncerImagePullSpec != "" {
+		brokerInfo.SubmarinerNetworkPluginSyncerImage = submarinerConfig.Spec.ImagePullSpecs.SubmarinerNetworkPluginSyncerImagePullSpec
 	}
 }
 

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
@@ -194,10 +194,11 @@ var _ = Describe("Function Get", func() {
 							StartingCSV:     "xyz",
 						},
 						ImagePullSpecs: configv1alpha1.SubmarinerImagePullSpecs{
-							SubmarinerImagePullSpec:           "quay.io/submariner/submariner-gateway:10.0.1",
-							LighthouseAgentImagePullSpec:      "quay.io/submariner/lighthouse-agent:10.0.1",
-							LighthouseCoreDNSImagePullSpec:    "quay.io/submariner/lighthouse-coredns:10.0.1",
-							SubmarinerRouteAgentImagePullSpec: "quay.io/submariner/submariner-route-agent:10.0.1",
+							SubmarinerImagePullSpec:                    "quay.io/submariner/submariner-gateway:10.0.1",
+							LighthouseAgentImagePullSpec:               "quay.io/submariner/lighthouse-agent:10.0.1",
+							LighthouseCoreDNSImagePullSpec:             "quay.io/submariner/lighthouse-coredns:10.0.1",
+							SubmarinerRouteAgentImagePullSpec:          "quay.io/submariner/submariner-route-agent:10.0.1",
+							SubmarinerNetworkPluginSyncerImagePullSpec: "quay.io/submariner/submariner-networkplugin-syncer:10.0.1",
 						},
 						CableDriver:        "wireguard",
 						IPSecNATTPort:      5678,
@@ -222,6 +223,8 @@ var _ = Describe("Function Get", func() {
 				Expect(brokerInfo.LoadBalancerEnabled).To(Equal(submarinerConfig.Spec.LoadBalancerEnable))
 				Expect(brokerInfo.SubmarinerGatewayImage).To(Equal(submarinerConfig.Spec.ImagePullSpecs.SubmarinerImagePullSpec))
 				Expect(brokerInfo.SubmarinerRouteAgentImage).To(Equal(submarinerConfig.Spec.ImagePullSpecs.SubmarinerRouteAgentImagePullSpec))
+				Expect(brokerInfo.SubmarinerNetworkPluginSyncerImage).To(Equal(
+					submarinerConfig.Spec.ImagePullSpecs.SubmarinerNetworkPluginSyncerImagePullSpec))
 			})
 
 			It("should return an empty GlobalCIDR as globalnet is disabled", func() {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -213,6 +213,7 @@ EOF
 {"op":"add","path":"/spec/imagePullSpecs/lighthouseAgentImagePullSpec","value":"'${submrepo}'/lighthouse-agent:'${submver}'"},
 {"op":"add","path":"/spec/imagePullSpecs/lighthouseCoreDNSImagePullSpec","value":"'${submrepo}'/lighthouse-coredns:'${submver}'"},
 {"op":"add","path":"/spec/imagePullSpecs/submarinerGlobalnetImagePullSpec","value":"'${submrepo}'/submariner-globalnet:'${submver}'"},
+{"op":"add","path":"/spec/imagePullSpecs/submarinerNetworkPluginSyncerImagePullSpec","value":"'${submrepo}'/submariner-networkplugin-syncer:'${submver}'"},
 {"op":"add","path":"/spec/NATTEnable","value":false}]'
 
 }


### PR DESCRIPTION
This adds option to override NetworkPluginSyncer image in `ImagePullspecs`. Submariner supports this override but option was missing from addon.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>