### PR TITLE
Konflux apply-tags fix

### DIFF
--- a/.tekton/submariner-addon-acm-214-pull-request.yaml
+++ b/.tekton/submariner-addon-acm-214-pull-request.yaml
@@ -539,8 +539,10 @@ spec:
               - "false"
       - name: apply-tags
         params:
-          - name: IMAGE
+          - name: IMAGE_URL
             value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         runAfter:
           - build-image-index
         taskRef:

--- a/.tekton/submariner-addon-acm-214-push.yaml
+++ b/.tekton/submariner-addon-acm-214-push.yaml
@@ -539,8 +539,10 @@ spec:
               - "false"
       - name: apply-tags
         params:
-          - name: IMAGE
+          - name: IMAGE_URL
             value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         runAfter:
           - build-image-index
         taskRef:


### PR DESCRIPTION
Builds on https://github.com/stolostron/submariner-addon/pull/2169 and adds a fix for the apply-tags migration.

I couldn't push to konflux/references/release-2.14 and update the original PR for some reason.