### PR TITLE
Add repository url label to container images

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -8,6 +8,7 @@ RUN make GO_BUILD_FLAGS=-mod=mod build --warn-undefined-variables
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL com.redhat.component="rhacm-submariner-addon" \
+      url="https://github.com/stolostron/submariner-addon" \
       description="This image provides the Submariner addon, which integrates with Red Hat Advanced Cluster Management (ACM) to establish secure and direct Layer 3 network connectivity between Kubernetes clusters." \
       io.k8s.description="Provides Submariner (cross-cluster L3 networking) capabilities as an addon managed by Red Hat Advanced Cluster Management." \
       io.k8s.display-name="Red Hat ACM Submariner Addon" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** release-2.15

**Components affected:** submariner-addon

**Branch details:** submariner-addon (branch: release-2.15)

**Label added:**
- url: https://github.com/stolostron/submariner-addon

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.