### PR TITLE
Switch to stable-0.23 channel

### DIFF
--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -33,7 +33,7 @@ const (
 	catalogName                   = "submariner"
 	defaultCatalogSource          = "redhat-operators"
 	defaultCatalogSourceNamespace = "openshift-marketplace"
-	defaultCatalogChannel         = "stable-0.22"
+	defaultCatalogChannel         = "stable-0.23"
 	defaultCableDriver            = "libreswan"
 	defaultInstallationNamespace  = "open-cluster-management-agent-addon"
 	brokerAPIServer               = "BROKER_API_SERVER"

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Function Get", func() {
 		When("no SubmarinerConfig is provided", func() {
 			It("should return the defaults", func() {
 				Expect(brokerInfo.CableDriver).To(Equal("libreswan"))
-				Expect(brokerInfo.CatalogChannel).To(Equal("stable-0.22"))
+				Expect(brokerInfo.CatalogChannel).To(Equal("stable-0.23"))
 				Expect(brokerInfo.CatalogName).To(Equal("submariner"))
 				Expect(brokerInfo.CatalogSource).To(Equal("redhat-operators"))
 				Expect(brokerInfo.CatalogSourceNamespace).To(Equal("openshift-marketplace"))


### PR DESCRIPTION
Switch default Submariner channel to stable-0.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Submariner broker channel from stable-0.22 to stable-0.23. This affects new deployments using default configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->