### PR TITLE
Fix the konflux dockerfile to address golang version difference

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.24.6-202510150934.g4284440.el9 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25 AS builder
 
 WORKDIR /go/src/github.com/stolostron/submariner-addon
 COPY . .


### PR DESCRIPTION
This build was broken due to using go 1.24 in the Dockerfile, but the go module was setup for 1.25

Refs:
 - https://redhat.atlassian.net/browse/ACM-32496