### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,22 @@
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /go/src/github.com/stolostron/submariner-addon
+COPY . .
+ENV GO_PACKAGE github.com/stolostron/submariner-addon
+RUN make GO_BUILD_FLAGS=-mod=mod build --warn-undefined-variables
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+LABEL com.redhat.component="rhacm-submariner-addon" \
+      url="https://github.com/stolostron/submariner-addon" \
+      description="This image provides the Submariner addon, which integrates with Red Hat Advanced Cluster Management (ACM) to establish secure and direct Layer 3 network connectivity between Kubernetes clusters." \
+      io.k8s.description="Provides Submariner (cross-cluster L3 networking) capabilities as an addon managed by Red Hat Advanced Cluster Management." \
+      io.k8s.display-name="Red Hat ACM Submariner Addon" \
+      io.openshift.tags="acm,submariner,networking,multicluster,redhat" \
+      name="submariner-addon-acm" \
+      summary="Submariner addon for Red Hat Advanced Cluster Management enabling cross-cluster network connectivity."
+
+COPY LICENSE /licenses/LICENSE
+COPY --from=builder /go/src/github.com/stolostron/submariner-addon/submariner /
+
+USER 1001


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)