### PR TITLE
Switch health endpoint from HTTPS (8443) to HTTP (8081)

### DIFF
--- a/deploy/config/operator/operator.yaml
+++ b/deploy/config/operator/operator.yaml
@@ -26,15 +26,15 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              scheme: HTTPS
-              port: 8443
+              scheme: HTTP
+              port: 8081
             initialDelaySeconds: 2
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /healthz
-              scheme: HTTPS
-              port: 8443
+              scheme: HTTP
+              port: 8081
             initialDelaySeconds: 2
           resources:
             requests:

--- a/pkg/cmd/hub/controller.go
+++ b/pkg/cmd/hub/controller.go
@@ -10,9 +10,15 @@ import (
 
 func NewController() *cobra.Command {
 	addOnOptions := hub.NewAddOnOptions()
-	cmd := controllercmd.
-		NewControllerCommandConfig("submariner-controller", version.Get(), addOnOptions.RunControllerManager, clock.RealClock{}).
-		NewCommand()
+
+	// Create base command config with serving disabled
+	cmdConfig := controllercmd.
+		NewControllerCommandConfig("submariner-controller", version.Get(), addOnOptions.RunControllerManager, clock.RealClock{})
+
+	// Disable controllercmd's HTTPS server - we'll use our own HTTP server
+	cmdConfig.DisableServing = true
+
+	cmd := cmdConfig.NewCommand()
 	cmd.Use = "controller"
 	cmd.Short = "Start the ACM Submariner Controller"
 

--- a/pkg/hub/manager.go
+++ b/pkg/hub/manager.go
@@ -3,6 +3,8 @@ package hub
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/pprof"
 	"os"
 	"time"
 
@@ -37,6 +39,7 @@ import (
 	workclient "open-cluster-management.io/api/client/work/clientset/versioned"
 	workinformers "open-cluster-management.io/api/client/work/informers/externalversions"
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -229,12 +232,45 @@ func (o *AddOnOptions) RunControllerManager(ctx context.Context, controllerConte
 		return errors.Wrap(err, "error adding agent")
 	}
 
+	// Start HTTP server on port 8081 for health checks and pprof debugging
+	// /healthz - Used by kubelet liveness/readiness probes
+	// /debug/pprof/* - Debug profiling endpoints (access via kubectl port-forward)
+	mux := http.NewServeMux()
+	mux.Handle("/healthz", healthz.CheckHandler{Checker: healthz.Ping})
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	healthServer := &http.Server{
+		Addr:              ":8081",
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		klog.Info("Starting HTTP server on :8081 (health checks and pprof debug endpoints)")
+
+		if err := healthServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			klog.Errorf("HTTP server error: %v", err)
+		}
+	}()
+
 	err = mgr.Start(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error starting addon manager")
 	}
 
 	<-ctx.Done()
+
+	// Shutdown HTTP server gracefully
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	//nolint:contextcheck // need a fresh context for shutdown since parent ctx is already cancelled
+	if err := healthServer.Shutdown(shutdownCtx); err != nil {
+		klog.Warningf("HTTP server shutdown error: %v", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
The` /healthz` endpoint is only accessed by kubelet liveness/readiness probes and does not serve any sensitive data so TLS encryption really isn't required. This change eliminates the need for TLS security profile compliance while maintaining health check functionality. Also library-go's `controllercmd` does not allow the TLS parameters to be configured (easily anyway).

Changes:
- Disabled controllercmd's built-in HTTPS server (DisableServing: true)
- Added HTTP server on port 8081 serving:
  - /healthz - Used by kubelet liveness/readiness probes
  - /debug/pprof/* - Go profiling endpoints for debugging
- Updated deployment probes: scheme HTTPS→HTTP, port 8443→8081

The `pprof` endpoints are accessible via kubectl port-forward and provide critical debugging capabilities (CPU profiling, heap analysis, goroutine dumps) without requiring TLS compliance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal controller command construction.

* **Infrastructure Updates**
  * Modified health check probes from HTTPS:8443 to HTTP:8081.
  * Added HTTP server on port 8081 with health status and profiling endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->