### PR TITLE
Update the catalog to use new probe ports

### DIFF
--- a/deploy/olm-catalog/0.3.0/submariner-addon.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/0.3.0/submariner-addon.clusterserviceversion.yaml
@@ -175,16 +175,16 @@ spec:
                 livenessProbe:
                   httpGet:
                     path: /healthz
-                    port: 8443
-                    scheme: HTTPS
+                    port: 8081
+                    scheme: HTTP
                   initialDelaySeconds: 2
                   periodSeconds: 10
                 name: submariner-addon
                 readinessProbe:
                   httpGet:
                     path: /healthz
-                    port: 8443
-                    scheme: HTTPS
+                    port: 8081
+                    scheme: HTTP
                   initialDelaySeconds: 2
                 resources:
                   requests:

--- a/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
@@ -325,16 +325,16 @@ spec:
                 livenessProbe:
                   httpGet:
                     path: /healthz
-                    port: 8443
-                    scheme: HTTPS
+                    port: 8081
+                    scheme: HTTP
                   initialDelaySeconds: 2
                   periodSeconds: 10
                 name: submariner-addon
                 readinessProbe:
                   httpGet:
                     path: /healthz
-                    port: 8443
-                    scheme: HTTPS
+                    port: 8081
+                    scheme: HTTP
                   initialDelaySeconds: 2
                 resources:
                   requests:


### PR DESCRIPTION
https://github.com/stolostron/submariner-addon/pull/2695 changed health endpoint from https (8443) to http (8081) but as part of this change missed updates to the CSVs to use the new ports.

This updates the CSVs to use the new ports for liveness and readiness probes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Submariner addon container health checks across deployment configurations. Both liveness and readiness probes now use HTTP on port 8081 instead of the previous HTTPS on port 8443, while retaining all probe paths and timing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->