### PR TITLE
Use the CSRApprover method from addon framework

### DIFF
--- a/pkg/hub/submarineraddonagent/agent.go
+++ b/pkg/hub/submarineraddonagent/agent.go
@@ -2,9 +2,7 @@ package submarineraddonagent
 
 import (
 	"context"
-	"crypto/x509"
 	"embed"
-	"encoding/pem"
 	goerrors "errors"
 	"fmt"
 	"os"
@@ -15,11 +13,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stolostron/submariner-addon/pkg/constants"
 	appsv1 "k8s.io/api/apps/v1"
-	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
@@ -34,13 +30,7 @@ import (
 const (
 	agentName                  = "submariner-addon-agent"
 	selfManagedClusterLabelKey = "local-cluster"
-)
-
-const (
-	addOnGroup         = "system:open-cluster-management:addon:submariner"
-	agentUserName      = "system:open-cluster-management:cluster:%s:addon:submariner:agent:submariner-addon-agent"
-	clusterAddOnGroup  = "system:open-cluster-management:cluster:%s:addon:submariner"
-	authenticatedGroup = "system:authenticated"
+	clusterAddOnGroup          = "system:open-cluster-management:cluster:%s:addon:submariner"
 )
 
 var agentHubPermissionFiles = []string{
@@ -76,7 +66,7 @@ func NewAddOnAgent(kubeClient kubernetes.Interface, clusterClient clusterclient.
 
 	registrationOption := &agent.RegistrationOption{
 		Configurations:   agent.KubeClientSignerConfigurations(constants.SubmarinerAddOnName, agentName),
-		CSRApproveCheck:  csrApproveCheck,
+		CSRApproveCheck:  utils.DefaultCSRApprover(agentName),
 		PermissionConfig: a.permissionConfig,
 	}
 
@@ -155,51 +145,6 @@ func (a *addOnAgent) getValues(cluster *clusterv1.ManagedCluster, _ *addonapiv1b
 	}
 
 	return addonfactory.StructToValues(manifestConfig), nil
-}
-
-// To check the addon agent csr, we check
-// 1. if the signer name in csr request is valid.
-// 2. if organization field and commonName field in csr request is valid.
-// 3. if user name in csr is the same as commonName field in csr request.
-func csrApproveCheck(ctx context.Context, cluster *clusterv1.ManagedCluster, _ *addonapiv1beta1.ManagedClusterAddOn,
-	csr *certificatesv1.CertificateSigningRequest,
-) bool {
-	if csr.Spec.SignerName != certificatesv1.KubeAPIServerClientSignerName {
-		return false
-	}
-
-	block, _ := pem.Decode(csr.Spec.Request)
-	if block == nil || block.Type != "CERTIFICATE REQUEST" {
-		klog.V(4).Infof("csr %q was not recognized: PEM block type is not CERTIFICATE REQUEST", csr.Name)
-
-		return false
-	}
-
-	x509cr, err := x509.ParseCertificateRequest(block.Bytes)
-	if err != nil {
-		klog.V(4).Infof("csr %q was not recognized: %v", csr.Name, err)
-
-		return false
-	}
-
-	requestingOrgs := sets.NewString(x509cr.Subject.Organization...)
-	if requestingOrgs.Len() != 3 {
-		return false
-	}
-
-	if !requestingOrgs.Has(authenticatedGroup) {
-		return false
-	}
-
-	if !requestingOrgs.Has(addOnGroup) {
-		return false
-	}
-
-	if !requestingOrgs.Has(fmt.Sprintf(clusterAddOnGroup, cluster.Name)) {
-		return false
-	}
-
-	return fmt.Sprintf(agentUserName, cluster.Name) == x509cr.Subject.CommonName
 }
 
 // Generates manifestworks to deploy the required roles of submariner-addon agent.

--- a/pkg/hub/submarineraddonagent/agent_test.go
+++ b/pkg/hub/submarineraddonagent/agent_test.go
@@ -206,7 +206,8 @@ var _ = Describe("GetAgentAddonOptions", func() {
 					"system:open-cluster-management:addon:submariner",
 					"system:open-cluster-management:cluster:" + clusterName + ":addon:submariner",
 				},
-				CN: "system:open-cluster-management:cluster:" + clusterName + ":addon:submariner:agent:submariner-addon-agent",
+				CN:       "system:open-cluster-management:cluster:" + clusterName + ":addon:submariner:agent:submariner-addon-agent",
+				Username: "system:open-cluster-management:" + clusterName + ":test-addon-sa",
 			}
 		})
 
@@ -215,7 +216,11 @@ var _ = Describe("GetAgentAddonOptions", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
 				},
-			}, &addonapiv1beta1.ManagedClusterAddOn{}, newCSR(csr))
+			}, &addonapiv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.SubmarinerAddOnName,
+				},
+			}, newCSR(&csr))
 		})
 
 		When("the CSR is valid", func() {
@@ -224,29 +229,9 @@ var _ = Describe("GetAgentAddonOptions", func() {
 			})
 		})
 
-		When("the signer name is invalid", func() {
-			BeforeEach(func() {
-				csr.SignerName = invalid
-			})
-
-			It("should return false", func() {
-				Expect(result).To(BeFalse())
-			})
-		})
-
 		When("the block type is invalid", func() {
 			BeforeEach(func() {
 				csr.ReqBlockType = "RSA PRIVATE KEY"
-			})
-
-			It("should return false", func() {
-				Expect(result).To(BeFalse())
-			})
-		})
-
-		When("the authenticated group is missing from the orgs", func() {
-			BeforeEach(func() {
-				csr.Orgs[0] = invalid
 			})
 
 			It("should return false", func() {
@@ -467,9 +452,10 @@ type csrHolder struct {
 	CN           string
 	Orgs         []string
 	ReqBlockType string
+	Username     string
 }
 
-func newCSR(holder csrHolder) *certificatesv1.CertificateSigningRequest {
+func newCSR(holder *csrHolder) *certificatesv1.CertificateSigningRequest {
 	//nolint:gosec // These are test credentials, using insecure rand vs crypto/rand is okay
 	insecureRand := rand.New(rand.NewSource(0))
 	pk, err := ecdsa.GenerateKey(elliptic.P256(), insecureRand)
@@ -487,13 +473,18 @@ func newCSR(holder csrHolder) *certificatesv1.CertificateSigningRequest {
 
 	Expect(err).To(Succeed())
 
+	username := holder.Username
+	if username == "" {
+		username = "test"
+	}
+
 	return &certificatesv1.CertificateSigningRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:         "test-csr",
 			GenerateName: "csr-",
 		},
 		Spec: certificatesv1.CertificateSigningRequestSpec{
-			Username:   "test",
+			Username:   username,
 			Usages:     []certificatesv1.KeyUsage{},
 			SignerName: holder.SignerName,
 			Request:    pem.EncodeToMemory(&pem.Block{Type: holder.ReqBlockType, Bytes: csrb}),


### PR DESCRIPTION
Addonframework has changed how it creates CSR. This causes a failure in csrApproveCheck().

Replace the custom ccsrApproveCheck with default provided by the framework. This will make sure that we don't need to keep the code in addon in sync with whatever changes framework makes in future.

Refer: https://github.com/open-cluster-management-io/addon-framework/commit/a60dd63a0abcbe82c8770a3dfba60d3cc8f86ed5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified CSR approval configuration and removed redundant CSR parsing and validation logic.
* **Tests**
  * Updated CSR-related tests and test data to include username handling and adjusted cases to match the new approval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->