### PR TITLE
Revert "Update the catalog to use new probe ports"

### DIFF
--- a/deploy/olm-catalog/0.3.0/submariner-addon.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/0.3.0/submariner-addon.clusterserviceversion.yaml
@@ -175,16 +175,16 @@ spec:
                 livenessProbe:
                   httpGet:
                     path: /healthz
-                    port: 8081
-                    scheme: HTTP
+                    port: 8443
+                    scheme: HTTPS
                   initialDelaySeconds: 2
                   periodSeconds: 10
                 name: submariner-addon
                 readinessProbe:
                   httpGet:
                     path: /healthz
-                    port: 8081
-                    scheme: HTTP
+                    port: 8443
+                    scheme: HTTPS
                   initialDelaySeconds: 2
                 resources:
                   requests:

--- a/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
@@ -325,16 +325,16 @@ spec:
                 livenessProbe:
                   httpGet:
                     path: /healthz
-                    port: 8081
-                    scheme: HTTP
+                    port: 8443
+                    scheme: HTTPS
                   initialDelaySeconds: 2
                   periodSeconds: 10
                 name: submariner-addon
                 readinessProbe:
                   httpGet:
                     path: /healthz
-                    port: 8081
-                    scheme: HTTP
+                    port: 8443
+                    scheme: HTTPS
                   initialDelaySeconds: 2
                 resources:
                   requests:


### PR DESCRIPTION
Reverts stolostron/submariner-addon#2700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated health check probes to use HTTPS protocol on port 8443, replacing the previous HTTP configuration on port 8081, for both readiness and liveness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->