### PR TITLE
Add RBAC for NetworkPolicies

### DIFF
--- a/deploy/config/rbac/cluster_role.yaml
+++ b/deploy/config/rbac/cluster_role.yaml
@@ -100,3 +100,7 @@ rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]
+# Add submariner-addon hub controller to manage NetworkPolicies (Conforma compliance)
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/submariner-addon.clusterserviceversion.yaml
@@ -298,6 +298,17 @@ spec:
           - create
           - update
           - delete
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
         serviceAccountName: submariner-addon
       deployments:
       - name: submariner-addon

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   creationTimestamp: null
   name: submarinerconfigs.submarineraddon.open-cluster-management.io
 spec:

--- a/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerdiagnoseconfigs.yaml
+++ b/deploy/olm-catalog/manifests/submarineraddon.open-cluster-management.io_submarinerdiagnoseconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   creationTimestamp: null
   name: submarinerdiagnoseconfigs.submarineraddon.open-cluster-management.io
 spec:


### PR DESCRIPTION
This is required for Conforma compliance check. This also prepares for upcoming changes to add NetworkPolicies to operator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the add-on operator’s permissions to manage Kubernetes NetworkPolicies, including viewing, creating, updating, and deleting policies.
  * This enables improved network policy management during add-on operations.

* **Chores**
  * Updated resource-generation metadata to the latest supported controller tooling version without changing the published resource schemas or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->