### PR TITLE
Drop spoke-agent update/patch privileges for hub resources

### DIFF
--- a/pkg/hub/submarineraddonagent/manifests/hub/role.yaml
+++ b/pkg/hub/submarineraddonagent/manifests/hub/role.yaml
@@ -4,20 +4,26 @@ metadata:
   name: open-cluster-management:submariner-addon:agent
   namespace: {{ .ClusterName }}
 rules:
-# Allow submariner-addon agent to operator managedclusteraddons on the hub cluster
+# Allow submariner-addon agent to read managedclusteraddons on the hub cluster.
+# The agent only writes status (UpdateStatus in pkg/addon/update_status.go).
 - apiGroups: ["addon.open-cluster-management.io"]
   resources: ["managedclusteraddons"]
-  verbs: ["get", "list", "watch", "update", "patch"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["addon.open-cluster-management.io"]
   resources: ["managedclusteraddons/finalizers"]
   verbs: ["update"]
 - apiGroups: ["addon.open-cluster-management.io"]
   resources: ["managedclusteraddons/status"]
   verbs: ["patch", "update"]
-# Allow submariner-addon agent to operator submarinerconfigs on the hub cluster
+# Allow submariner-addon agent to read submarinerconfigs on the hub cluster.
+# The agent must NOT have update/patch on the main resource: spec.imagePullSpecs
+# and spec.subscriptionConfig flow verbatim into privileged hostNetwork pods on
+# the spoke, so a compromised spoke could otherwise write its own SubmarinerConfig
+# spec to gain arbitrary code execution on its gateway nodes. The agent only
+# writes status (UpdateStatus in pkg/spoke/submarineragent/config_controller.go).
 - apiGroups: ["submarineraddon.open-cluster-management.io"]
   resources: ["submarinerconfigs"]
-  verbs: ["get", "list", "watch", "update", "patch"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["submarineraddon.open-cluster-management.io"]
   resources: ["submarinerconfigs/finalizers"]
   verbs: ["update"]


### PR DESCRIPTION
`SubmarinerConfig.spec.imagePullSpecs` (7 free-form image refs) and `spec.subscriptionConfig` flow with no allow-list, registry pin, or digest check via `brokerinfo.applySubmarinerImageConfig` into `imageOverrides` on the spoke's `Submariner` CR (delivered via `ManifestWork`). **submariner-gateway** / **route-agent** run hostNetwork + NET_ADMIN + privileged. The hub-side agent Role gave each spoke's addon-agent `ServiceAccount` update/patch on submarinerconfigs in its own per-cluster namespace, so a compromised spoke could rewrite its own `SubmarinerConfig.spec `on the hub and have the hub deploy an attacker-controlled image as a privileged host-network pod on the spoke's gateway nodes.

The spoke agent only reads `SubmarinerConfig` and writes the `/status` subresource. Drop update/patch on the main resource; keep get/list/watch and the existing /status and /finalizers rules.

Same with `ManagedClusterAddOn`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Restricted the hub agent’s access to configuration resources to read-only operations.
  * Preserved permission to update resource status and finalizers.
  * Added documentation clarifying protected configuration fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->