### PR TITLE
Move sensitive cleartext storage fields to Secret fields in Submariner CR

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -12,7 +12,8 @@ const (
 	ProductOSD        = "OpenShiftDedicated"
 	OCPVersionForOVNK = "4.11.0-rc"
 
-	IPSecPSKSecretName = "submariner-ipsec-psk"
+	IPSecPSKSecretName  = "submariner-ipsec-psk"
+	BrokerK8sSecretName = "submariner-broker-secret"
 
 	SubmarinerNatTPort          = 4500
 	SubmarinerNatTDiscoveryPort = 4900

--- a/pkg/hub/submarineragent/controller.go
+++ b/pkg/hub/submarineragent/controller.go
@@ -72,6 +72,7 @@ const (
 	SubmarinerCRManifestWorkName  = "submariner-resource"
 	agentRBACFile                 = "manifests/rbac/operatorgroup-aggregate-clusterrole.yaml"
 	submarinerCRFile              = "manifests/operator/submariner.io-submariners-cr.yaml"
+	submarinerIPSecPSKSecretFile  = "manifests/operator/submariner-ipsec-psk-secret.yaml"
 	operatorNamespaceFile         = "manifests/operator/submariner-operator-namespace.yaml"
 	BrokerCfgApplied              = "SubmarinerBrokerConfigApplied"
 	BrokerObjectName              = "submariner-broker"
@@ -624,7 +625,9 @@ func (c *submarinerAgentController) removeClusterRBACFiles(ctx context.Context, 
 }
 
 func newSubmarinerManifestWork(managedCluster *clusterv1.ManagedCluster, config any) (*workv1.ManifestWork, error) {
-	return newManifestWork(SubmarinerCRManifestWorkName, managedCluster.Name, config, submarinerCRFile)
+	return newManifestWork(SubmarinerCRManifestWorkName, managedCluster.Name, config,
+		submarinerIPSecPSKSecretFile, // Secret first, so it exists before CR references it
+		submarinerCRFile)
 }
 
 func newOperatorManifestWork(managedCluster *clusterv1.ManagedCluster, config any, skipOperatorGroup bool,

--- a/pkg/hub/submarineragent/controller.go
+++ b/pkg/hub/submarineragent/controller.go
@@ -73,6 +73,7 @@ const (
 	agentRBACFile                 = "manifests/rbac/operatorgroup-aggregate-clusterrole.yaml"
 	submarinerCRFile              = "manifests/operator/submariner.io-submariners-cr.yaml"
 	submarinerIPSecPSKSecretFile  = "manifests/operator/submariner-ipsec-psk-secret.yaml"
+	submarinerBrokerSecretFile    = "manifests/operator/submariner-broker-secret.yaml"
 	operatorNamespaceFile         = "manifests/operator/submariner-operator-namespace.yaml"
 	BrokerCfgApplied              = "SubmarinerBrokerConfigApplied"
 	BrokerObjectName              = "submariner-broker"
@@ -626,7 +627,8 @@ func (c *submarinerAgentController) removeClusterRBACFiles(ctx context.Context, 
 
 func newSubmarinerManifestWork(managedCluster *clusterv1.ManagedCluster, config any) (*workv1.ManifestWork, error) {
 	return newManifestWork(SubmarinerCRManifestWorkName, managedCluster.Name, config,
-		submarinerIPSecPSKSecretFile, // Secret first, so it exists before CR references it
+		submarinerIPSecPSKSecretFile, // Secrets first, so they exist before CR references them
+		submarinerBrokerSecretFile,
 		submarinerCRFile)
 }
 

--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -801,6 +801,15 @@ func (t *testDriver) awaitSubmarinerManifestWork() {
 func (t *testDriver) assertSubmarinerManifestWork(work *workv1.ManifestWork) {
 	manifestObjs := unmarshallManifestObjs(work)
 
+	// Assert IPSec PSK Secret
+	secret := &corev1.Secret{}
+	Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(
+		assertManifestObj(manifestObjs, "Secret", constants.IPSecPSKSecretName).Object, secret)).To(Succeed())
+	Expect(secret.Namespace).To(Equal(installNamespace))
+	// Secret.Data is automatically base64-decoded when unmarshalled from JSON/YAML
+	Expect(secret.Data["psk"]).To(Equal([]byte(ipsecPSK)))
+
+	// Assert Submariner CR
 	submariner := &submarinerv1alpha1.Submariner{}
 	Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(
 		assertManifestObj(manifestObjs, "Submariner", "").Object, submariner)).To(Succeed())
@@ -809,7 +818,8 @@ func (t *testDriver) assertSubmarinerManifestWork(work *workv1.ManifestWork) {
 	Expect(submariner.Spec.BrokerK8sApiServerToken).To(Equal(brokerToken))
 	Expect(submariner.Spec.BrokerK8sCA).To(Equal(base64.StdEncoding.EncodeToString([]byte(brokerCA))))
 	Expect(submariner.Spec.BrokerK8sRemoteNamespace).To(Equal(brokerNamespace))
-	Expect(submariner.Spec.CeIPSecPSK).To(Equal(base64.StdEncoding.EncodeToString([]byte(ipsecPSK))))
+	Expect(submariner.Spec.CeIPSecPSKSecret).To(Equal(constants.IPSecPSKSecretName))
+	Expect(submariner.Spec.CeIPSecPSK).To(BeEmpty())
 	Expect(submariner.Spec.ClusterID).To(Equal(clusterName))
 	Expect(submariner.Spec.Namespace).To(Equal(installNamespace))
 

--- a/pkg/hub/submarineragent/controller_test.go
+++ b/pkg/hub/submarineragent/controller_test.go
@@ -2,7 +2,6 @@ package submarineragent_test
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -809,14 +808,24 @@ func (t *testDriver) assertSubmarinerManifestWork(work *workv1.ManifestWork) {
 	// Secret.Data is automatically base64-decoded when unmarshalled from JSON/YAML
 	Expect(secret.Data["psk"]).To(Equal([]byte(ipsecPSK)))
 
+	// Assert Broker Secret
+	brokerSecret := &corev1.Secret{}
+	Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(
+		assertManifestObj(manifestObjs, "Secret", constants.BrokerK8sSecretName).Object, brokerSecret)).To(Succeed())
+	Expect(brokerSecret.Namespace).To(Equal(installNamespace))
+	// Secret.Data is automatically base64-decoded when unmarshalled from JSON/YAML
+	Expect(brokerSecret.Data["token"]).To(Equal([]byte(brokerToken)))
+	Expect(brokerSecret.Data["ca.crt"]).To(Equal([]byte(brokerCA)))
+
 	// Assert Submariner CR
 	submariner := &submarinerv1alpha1.Submariner{}
 	Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(
 		assertManifestObj(manifestObjs, "Submariner", "").Object, submariner)).To(Succeed())
 	Expect(submariner.Namespace).To(Equal(installNamespace))
 	Expect(submariner.Spec.BrokerK8sApiServer).To(Equal("127.0.0.1"))
-	Expect(submariner.Spec.BrokerK8sApiServerToken).To(Equal(brokerToken))
-	Expect(submariner.Spec.BrokerK8sCA).To(Equal(base64.StdEncoding.EncodeToString([]byte(brokerCA))))
+	Expect(submariner.Spec.BrokerK8sSecret).To(Equal(constants.BrokerK8sSecretName))
+	Expect(submariner.Spec.BrokerK8sApiServerToken).To(BeEmpty())
+	Expect(submariner.Spec.BrokerK8sCA).To(BeEmpty())
 	Expect(submariner.Spec.BrokerK8sRemoteNamespace).To(Equal(brokerNamespace))
 	Expect(submariner.Spec.CeIPSecPSKSecret).To(Equal(constants.IPSecPSKSecretName))
 	Expect(submariner.Spec.CeIPSecPSK).To(BeEmpty())

--- a/pkg/hub/submarineragent/manifests/operator/submariner-broker-secret.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner-broker-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: submariner-broker-secret
+  namespace: {{ .InstallationNamespace }}
+type: Opaque
+data:
+  token: {{ .BrokerToken }}
+  ca.crt: {{ .BrokerCA }}

--- a/pkg/hub/submarineragent/manifests/operator/submariner-ipsec-psk-secret.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner-ipsec-psk-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: submariner-ipsec-psk
+  namespace: {{ .InstallationNamespace }}
+type: Opaque
+data:
+  psk: {{ .IPSecPSK }}

--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -6,8 +6,7 @@ metadata:
 spec:
   broker: k8s
   brokerK8sApiServer: {{ .BrokerAPIServer }}
-  brokerK8sApiServerToken: {{ .BrokerToken }}
-  brokerK8sCA: {{ .BrokerCA }}
+  brokerK8sSecret: submariner-broker-secret
   brokerK8sRemoteNamespace: {{ .BrokerNamespace }}
   brokerK8sInsecure: {{ .InsecureBrokerConnection }}
   cableDriver: {{ .CableDriver }}

--- a/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
+++ b/pkg/hub/submarineragent/manifests/operator/submariner.io-submariners-cr.yaml
@@ -14,7 +14,7 @@ spec:
   ceIPSecDebug: {{ .IPSecDebug }}
   ceIPSecForceUDPEncaps: {{ .ForceUDPEncaps }}
   ceIPSecNATTPort: {{ .IPSecNATTPort }}
-  ceIPSecPSK: {{ .IPSecPSK }}
+  ceIPSecPSKSecret: submariner-ipsec-psk
   ceIPSecUseOVNCertAuthMode: {{ .CeIPSecUseOVNCertAuthMode }}
   clusterCIDR: ""
   globalCIDR: "{{ .GlobalCIDR }}"

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo.go
@@ -406,10 +406,12 @@ func getTokenAndCAFromSecret(ctx context.Context, tokenSecret *corev1.Secret, ku
 	}
 
 	if kubeAPIServerCA == nil {
-		return string(tokenSecret.Data["token"]), base64.StdEncoding.EncodeToString(tokenSecret.Data["ca.crt"]), nil
+		return base64.StdEncoding.EncodeToString(tokenSecret.Data["token"]),
+			base64.StdEncoding.EncodeToString(tokenSecret.Data["ca.crt"]), nil
 	}
 
-	return string(tokenSecret.Data["token"]), base64.StdEncoding.EncodeToString(kubeAPIServerCA), nil
+	return base64.StdEncoding.EncodeToString(tokenSecret.Data["token"]),
+		base64.StdEncoding.EncodeToString(kubeAPIServerCA), nil
 }
 
 func GenerateBrokerName(name string) string {

--- a/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
+++ b/pkg/hub/submarinerbrokerinfo/brokerinfo_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Function Get", func() {
 		It("should return the correct broker credentials", func() {
 			Expect(brokerInfo.BrokerNamespace).To(Equal(brokerNamespace))
 			Expect(brokerInfo.BrokerAPIServer).To(Equal(apiServerHostPort))
-			Expect(brokerInfo.BrokerToken).To(Equal(brokerToken))
+			Expect(brokerInfo.BrokerToken).To(Equal(base64.StdEncoding.EncodeToString([]byte(brokerToken))))
 			Expect(brokerInfo.BrokerCA).To(Equal(base64.StdEncoding.EncodeToString([]byte(brokerCA))))
 		})
 

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -7,9 +7,9 @@ import (
 
 var fieldsToRedact = []string{
 	"brokerK8sApiServer",
-	"brokerK8sApiServerToken",
-	"brokerK8sCA",
-	"ceIPSecPSK",
+	"token",
+	"ca.crt",
+	"psk",
 }
 
 var regex *regexp.Regexp
@@ -18,14 +18,14 @@ func init() {
 	var sb strings.Builder
 
 	sb.WriteString("(\"(")
-	sb.WriteString(fieldsToRedact[0])
+	sb.WriteString(regexp.QuoteMeta(fieldsToRedact[0]))
 
 	for i := 1; i < len(fieldsToRedact); i++ {
 		sb.WriteString("|")
-		sb.WriteString(fieldsToRedact[i])
+		sb.WriteString(regexp.QuoteMeta(fieldsToRedact[i]))
 	}
 
-	sb.WriteString(")\"\\s*:\\s*)\".*\"")
+	sb.WriteString(")\"\\s*:\\s*)\"(\\\\.|[^\"\\\\])*\"")
 
 	regex = regexp.MustCompile(sb.String())
 }

--- a/test/integration/deploying_submariner_test.go
+++ b/test/integration/deploying_submariner_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -13,11 +14,13 @@ import (
 	"github.com/stolostron/submariner-addon/test/util"
 	"github.com/submariner-io/admiral/pkg/finalizer"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	"open-cluster-management.io/api/client/addon/clientset/versioned/scheme"
+	workv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -42,7 +45,21 @@ var _ = Describe("Submariner Deployment", func() {
 		})
 
 		It("should successfully deploy the submariner ManifestWork resources", func() {
-			awaitSubmarinerManifestWorks(managedClusterName)
+			works := awaitSubmarinerManifestWorks(managedClusterName)
+
+			submarinerCRWork := works[1]
+			Expect(submarinerCRWork.Spec.Workload.Manifests).To(HaveLen(2), "Expected 2 manifests (PSK Secret and Submariner CR)")
+
+			// Verify PSK Secret manifest
+			secret := &corev1.Secret{}
+			Expect(json.Unmarshal(submarinerCRWork.Spec.Workload.Manifests[0].Raw, secret)).To(Succeed())
+			Expect(secret.Name).To(Equal(constants.IPSecPSKSecretName))
+			Expect(secret.Data["psk"]).NotTo(BeEmpty(), "PSK data should not be empty")
+
+			// Verify Submariner CR manifest
+			submariner := &v1alpha1.Submariner{}
+			Expect(json.Unmarshal(submarinerCRWork.Spec.Workload.Manifests[1].Raw, submariner)).To(Succeed())
+			Expect(submariner.Spec.CeIPSecPSKSecret).To(Equal(constants.IPSecPSKSecretName))
 		})
 	})
 
@@ -191,9 +208,10 @@ var _ = Describe("Submariner Deployment", func() {
 	})
 })
 
-func awaitSubmarinerManifestWorks(managedClusterName string) {
+func awaitSubmarinerManifestWorks(managedClusterName string) []*workv1.ManifestWork {
 	By("Await deployment of the ManifestWorks")
-	awaitManifestWorks(workClient, managedClusterName, submarineragent.OperatorManifestWorkName,
+
+	return awaitManifestWorks(workClient, managedClusterName, submarineragent.OperatorManifestWorkName,
 		submarineragent.SubmarinerCRManifestWorkName)
 }
 

--- a/test/integration/deploying_submariner_test.go
+++ b/test/integration/deploying_submariner_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	"open-cluster-management.io/api/client/addon/clientset/versioned/scheme"
@@ -47,19 +47,45 @@ var _ = Describe("Submariner Deployment", func() {
 		It("should successfully deploy the submariner ManifestWork resources", func() {
 			works := awaitSubmarinerManifestWorks(managedClusterName)
 
-			submarinerCRWork := works[1]
-			Expect(submarinerCRWork.Spec.Workload.Manifests).To(HaveLen(2), "Expected 2 manifests (PSK Secret and Submariner CR)")
+			var submarinerCRWork *workv1.ManifestWork
+
+			for _, w := range works {
+				if w.Name == submarineragent.SubmarinerCRManifestWorkName {
+					submarinerCRWork = w
+					break
+				}
+			}
+
+			Expect(submarinerCRWork).NotTo(BeNil(), "SubmarinerCR ManifestWork not found")
+
+			Expect(submarinerCRWork.Spec.Workload.Manifests).To(HaveLen(3),
+				"Expected 3 manifests (PSK Secret, Broker Secret, and Submariner CR)")
+
+			manifestObjs := util.UnmarshallManifestObjs(submarinerCRWork)
 
 			// Verify PSK Secret manifest
-			secret := &corev1.Secret{}
-			Expect(json.Unmarshal(submarinerCRWork.Spec.Workload.Manifests[0].Raw, secret)).To(Succeed())
-			Expect(secret.Name).To(Equal(constants.IPSecPSKSecretName))
-			Expect(secret.Data["psk"]).NotTo(BeEmpty(), "PSK data should not be empty")
+			pskSecret := &corev1.Secret{}
+			Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(
+				util.AssertManifestObj(manifestObjs, "Secret", constants.IPSecPSKSecretName).Object, pskSecret)).To(Succeed())
+			Expect(pskSecret.Name).To(Equal(constants.IPSecPSKSecretName))
+			Expect(pskSecret.Data["psk"]).NotTo(BeEmpty(), "PSK data should not be empty")
+
+			// Verify Broker Secret manifest
+			brokerSecret := &corev1.Secret{}
+			Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(
+				util.AssertManifestObj(manifestObjs, "Secret", constants.BrokerK8sSecretName).Object, brokerSecret)).To(Succeed())
+			Expect(brokerSecret.Name).To(Equal(constants.BrokerK8sSecretName))
+			Expect(brokerSecret.Data["token"]).NotTo(BeEmpty(), "Broker token should not be empty")
+			Expect(brokerSecret.Data["ca.crt"]).NotTo(BeEmpty(), "Broker CA should not be empty")
 
 			// Verify Submariner CR manifest
 			submariner := &v1alpha1.Submariner{}
-			Expect(json.Unmarshal(submarinerCRWork.Spec.Workload.Manifests[1].Raw, submariner)).To(Succeed())
+			Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(
+				util.AssertManifestObj(manifestObjs, "Submariner", "").Object, submariner)).To(Succeed())
 			Expect(submariner.Spec.CeIPSecPSKSecret).To(Equal(constants.IPSecPSKSecretName))
+			Expect(submariner.Spec.BrokerK8sSecret).To(Equal(constants.BrokerK8sSecretName))
+			Expect(submariner.Spec.BrokerK8sApiServerToken).To(BeEmpty())
+			Expect(submariner.Spec.BrokerK8sCA).To(BeEmpty())
 		})
 	})
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -289,3 +289,29 @@ func (r *IntegrationTestEventRecorder) Warningf(reason, messageFmt string, args 
 
 func (r *IntegrationTestEventRecorder) Shutdown() {
 }
+
+func UnmarshallManifestObjs(work *workv1.ManifestWork) []*unstructured.Unstructured {
+	manifestObjs := make([]*unstructured.Unstructured, len(work.Spec.Workload.Manifests))
+
+	for i := range work.Spec.Workload.Manifests {
+		obj := &unstructured.Unstructured{}
+		err := obj.UnmarshalJSON(work.Spec.Workload.Manifests[i].Raw)
+		Expect(err).To(Succeed())
+
+		manifestObjs[i] = obj
+	}
+
+	return manifestObjs
+}
+
+func AssertManifestObj(objs []*unstructured.Unstructured, kind, name string) *unstructured.Unstructured {
+	for _, o := range objs {
+		if o.GetKind() == kind && (name == "" || o.GetName() == name) {
+			return o
+		}
+	}
+
+	Fail(fmt.Sprintf("Expected manifest resource with kind %q and name %q", kind, name))
+
+	return nil
+}


### PR DESCRIPTION
For broker token/CA and IPsec PSK. See commits for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credentials are now delivered through Kubernetes Secrets for improved deployment configuration.
  * Added dedicated Secrets for broker credentials and the IPsec pre-shared key.
  * Submariner deployments now reference these Secrets instead of embedding credential values directly.

* **Bug Fixes**
  * Broker service-account tokens are consistently encoded for deployment use.

* **Tests**
  * Expanded deployment validation to verify Secret contents, namespaces, and credential references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->